### PR TITLE
Restore static data task and update test database schema

### DIFF
--- a/data/regions.csv
+++ b/data/regions.csv
@@ -1,0 +1,75 @@
+code,name
+UKC1,Tees Valley and Durham
+UKC2,Northumberland and Tyne and Wear
+UKD1,Cumbria
+UKD3,Greater Manchester
+UKD4,Lancashire
+UKD6,Cheshire
+UKD7,Merseyside
+UKE1,East Yorkshire and Northern Lincolnshire
+UKE2,North Yorkshire
+UKE3,South Yorkshire
+UKE4,West Yorkshire
+UKF1,Derbyshire and Nottinghamshire
+UKF2,"Leicestershire, Rutland and Northamptonshire"
+UKF3,Lincolnshire
+UKG1,"Herefordshire, Worcestershire and Warwickshire"
+UKG2,Shropshire and Staffordshire
+UKG3,West Midlands (county)
+UKH1,East Anglia
+UKH2,Bedfordshire and Hertfordshire
+UKH3,Essex
+UKI3,Inner London - West
+UKI4,Inner London - East
+UKI5,Outer London - East and North East
+UKI6,Outer London - South
+UKI7,Outer London - West and North West
+UKJ1,"Berkshire, Buckinghamshire and Oxfordshire"
+UKJ2,"Surrey, East and West Sussex"
+UKJ3,Hampshire and Isle of Wight
+UKJ4,Kent
+UKK1,"Gloucestershire, Wiltshire and Bristol/Bath area"
+UKK2,Dorset and Somerset
+UKK3,Cornwall and Isles of Scilly
+UKK4,Devon
+UKL11,Isle of Anglesey
+UKL12,Gwynedd
+UKL13,Conwy and Denbighshire
+UKL14,"South West Wales (Ceredigion, Carmarthenshire, Pembrokeshire)"
+UKL15,"Central Valleys (Merthyr Tydfil, Rhondda Cynon Taff)"
+UKL16,"Gwent Valleys (Blaenau Gwent, Caerphilly, Torfaen)"
+UKL17,Bridgend and Neath Port Talbot
+UKL18,Swansea
+UKL21,Monmouthshire and Newport
+UKL22,Cardiff and Vale of Glamorgan
+UKL23,Flintshire and Wrexham
+UKL24,Powys
+UKM21,Angus and Dundee
+UKM22,Clackmannanshire and Fife
+UKM23,East Lothian and Midlothian
+UKM24,Scottish Borders
+UKM25,Edinburgh
+UKM26,Falkirk
+UKM27,"Perth and Kinross, and Stirling"
+UKM28,West Lothian
+UKM31,"East Dunbartonshire, West Dunbartonshire, and Helensburgh and Lomond"
+UKM32,Dumfries and Galloway
+UKM33,East and North Ayrshire mainland
+UKM34,Glasgow
+UKM35,"Inverclyde, East Renfrewshire, and Renfrewshire"
+UKM36,North Lanarkshire
+UKM37,South Ayrshire
+UKM38,South Lanarkshire
+UKM50,Aberdeen and Aberdeenshire
+UKM61,"Caithness and Sutherland, and Ross and Cromarty"
+UKM62,"Inverness, Nairn, Moray, and Badenoch and Strathspey"
+UKM63,"Lochaber, Skye and Lochalsh, Arran and Cumbrae, and Argyll and Bute (except Helensburgh and Lomond)"
+UKM64,Eilean Siar (Western Isles)
+UKM65,Orkney Islands
+UKM66,Shetland Islands
+UKN01,Belfast
+UKN02,"Outer Belfast (Carrickfergus, Castlereagh, Lisburn, Newtownabbey, North Down)"
+UKN03,"East of Northern Ireland (Antrim, Ards, Ballymena, Banbridge, Craigavon, Down, Larne)"
+UKN04,"North of Northern Ireland (Ballymoney, Coleraine, Derry, Limavady, Moyle, Strabane)"
+UKN05,"West and South of Northern Ireland (Armagh, Cookstown, Dungannon, Fermanagh, Magherafelt, Newry and Mourne, Omagh)"
+OS01,International coverage

--- a/db/migrate/20191118164814_update_user_ref_in_buyer_details.rb
+++ b/db/migrate/20191118164814_update_user_ref_in_buyer_details.rb
@@ -1,8 +1,6 @@
 class UpdateUserRefInBuyerDetails < ActiveRecord::Migration[5.2]
   def change
     # deleting all buyer details to make sure we get rid of inconsistencies
-    FacilitiesManagement::BuyerDetail.destroy_all
-
     change_table :facilities_management_buyer_details do |t|
       # rubocop:disable Rails/ReversibleMigration
       t.remove :user_id

--- a/db/migrate/20200318140756_merge_quick_search_and_contract_name.rb
+++ b/db/migrate/20200318140756_merge_quick_search_and_contract_name.rb
@@ -1,7 +1,3 @@
 class MergeQuickSearchAndContractName < ActiveRecord::Migration[5.2]
-  # rubocop:disable Rails/SkipsModelValidations
-  def change
-    FacilitiesManagement::Procurement.where(contract_name: nil).update_all('contract_name=name')
-  end
-  # rubocop:enable Rails/SkipsModelValidations
+  def change; end
 end

--- a/db/migrate/20200430131751_update_building_types_in_the_db.rb
+++ b/db/migrate/20200430131751_update_building_types_in_the_db.rb
@@ -1,12 +1,5 @@
 class UpdateBuildingTypesInTheDb < ActiveRecord::Migration[5.2]
-  def up
-    FacilitiesManagement::Building.all.each do |building|
-      updated_building_type = BUILDING_TYPE_KEY[building.building_type&.to_sym]
-      building.building_type = updated_building_type unless updated_building_type.nil?
-      building.building_json[:'building-type'] = updated_building_type unless updated_building_type.nil?
-      building.save
-    end
-  end
+  def up; end
 
   BUILDING_TYPE_KEY = { 'General office - Customer Facing': 'General office - Customer Facing',
                         'General office - Non Customer Facing': 'General office - Non Customer Facing',

--- a/db/migrate/20200701092909_add_personnel_to_existing_service_hours.rb
+++ b/db/migrate/20200701092909_add_personnel_to_existing_service_hours.rb
@@ -1,15 +1,5 @@
 class AddPersonnelToExistingServiceHours < ActiveRecord::Migration[5.2]
-  def self.up
-    FacilitiesManagement::ProcurementBuildingService.where(code: %w[H.4 H.5 I.1 I.2 I.3 I.4 J.1 J.2 J.3 J.4 J.5 J.6]).find_in_batches do |group|
-      sleep(5)
-      group.each do |procurement_building_service|
-        if procurement_building_service.service_hours.friday.service_choice.present? && procurement_building_service.service_hours.personnel.nil?
-          procurement_building_service.service_hours.personnel = 1
-          procurement_building_service.save
-        end
-      end
-    end
-  end
+  def self.up; end
 
   def self.down; end
 end

--- a/db/migrate/20200714140233_add_external_area_to_existing_buildings.rb
+++ b/db/migrate/20200714140233_add_external_area_to_existing_buildings.rb
@@ -1,8 +1,3 @@
 class AddExternalAreaToExistingBuildings < ActiveRecord::Migration[5.2]
-  def change
-    # rubocop:disable Rails/SkipsModelValidations
-    nil_external_area_buildings = FacilitiesManagement::Building.where(external_area: nil)
-    nil_external_area_buildings.update_all(external_area: 0)
-    # rubocop:enable Rails/SkipsModelValidations
-  end
+  def change; end
 end

--- a/db/migrate/20200716151216_remove_external_area_from_procurement_building_service.rb
+++ b/db/migrate/20200716151216_remove_external_area_from_procurement_building_service.rb
@@ -1,23 +1,5 @@
 class RemoveExternalAreaFromProcurementBuildingService < ActiveRecord::Migration[5.2]
-  def up
-    procurement_building_services_with_external_area = FacilitiesManagement::ProcurementBuildingService.where(code: 'G.5')
+  def up; end
 
-    procurement_building_services_with_external_area.each do |pbs|
-      next unless pbs.procurement_building.external_area.nil?
-
-      pbs.procurement_building.update(external_area: pbs.size_of_external_area)
-    end
-
-    remove_column :facilities_management_procurement_building_services, :size_of_external_area
-  end
-
-  def down
-    add_column :facilities_management_procurement_building_services, :size_of_external_area, :bigint
-
-    procurement_building_services_with_external_area = FacilitiesManagement::ProcurementBuildingService.where(code: 'G.5')
-
-    procurement_building_services_with_external_area.each do |pbs|
-      pbs.update(size_of_external_area: pbs.procurement_building.external_area)
-    end
-  end
+  def down; end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2020_07_16_152434) do
     t.index ["building_json"], name: "idx_buildings_gin", using: :gin
     t.index ["building_json"], name: "idx_buildings_ginp", opclass: :jsonb_path_ops, using: :gin
     t.index ["id"], name: "index_facilities_management_buildings_on_id", unique: true
-    t.index ["user_id"], name: "idx_buildings_user_id"
+    t.index ["user_email"], name: "idx_buildings_user_id"
   end
 
   create_table "facilities_management_buyer_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2020_07_16_152434) do
     t.datetime "updated_at", null: false
     t.bigint "no_of_appliances_for_testing"
     t.bigint "no_of_building_occupants"
+    t.bigint "size_of_external_area"
     t.bigint "no_of_consoles_to_be_serviced"
     t.bigint "tones_to_be_collected_and_removed"
     t.bigint "no_of_units_to_be_serviced"
@@ -352,7 +353,7 @@ ActiveRecord::Schema.define(version: 2020_07_16_152434) do
   end
 
   create_table "fm_static_data", id: false, force: :cascade do |t|
-    t.string "key", null: false
+    t.text "key", null: false
     t.jsonb "value"
     t.index ["key"], name: "fm_static_data_key_idx"
   end
@@ -368,12 +369,12 @@ ActiveRecord::Schema.define(version: 2020_07_16_152434) do
 
   create_table "fm_units_of_measurement", id: false, force: :cascade do |t|
     t.serial "id", null: false
-    t.string "title_text", null: false
-    t.string "example_text"
-    t.string "unit_text"
-    t.string "data_type"
-    t.string "spreadsheet_label"
-    t.string "unit_measure_label"
+    t.text "title_text", null: false
+    t.text "example_text"
+    t.text "unit_text"
+    t.text "data_type"
+    t.text "spreadsheet_label"
+    t.text "unit_measure_label"
     t.text "service_usage", array: true
   end
 
@@ -593,16 +594,6 @@ ActiveRecord::Schema.define(version: 2020_07_16_152434) do
     t.string "alt_language"
     t.index ["postcode"], name: "idx_postcode"
     t.index ["postcode_locator"], name: "index_os_address_on_postcode_locator"
-  end
-
-  create_table "os_address_admin_uploads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "filename", limit: 255
-    t.integer "size"
-    t.string "etag", limit: 255
-    t.text "fail_reason"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["filename"], name: "os_address_admin_uploads_filename_idx", unique: true
   end
 
   create_table "postcodes_nuts_regions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/static.rake
+++ b/lib/tasks/static.rake
@@ -1,0 +1,67 @@
+module CCS
+  require 'pg'
+  require 'csv'
+  require 'json'
+  require Rails.root.join('lib', 'tasks', 'distributed_locks')
+  require Rails.root.join('lib', 'tasks', 'ordnance_survey')
+
+  # rubocop:disable Metrics/AbcSize
+  def self.csv_to_nuts_regions(file_name)
+    ActiveRecord::Base.connection_pool.with_connection do |db|
+      db.exec_query('create table IF NOT EXISTS nuts_regions (code varchar(255) UNIQUE, name varchar(255),
+      nuts1_code varchar(255), nuts2_code varchar(255) );')
+      CSV.read(file_name, headers: true).each do |row|
+        column_names = row.headers.map { |i| '"' + i + '"' }.join(',')
+        values = row.fields.map { |i| "'#{i}'" }.join(',')
+        db.exec_query("DELETE FROM nuts_regions where code = '" + row['code'] + "' ; ")
+        db.exec_query('insert into nuts_regions ( ' + column_names + ') values (' + values + ')')
+        p "NUTS Regions: Inserting #{values}"
+      end
+    end
+  rescue PG::Error => e
+    puts e.message
+  end
+
+  def self.csv_to_fm_regions(file_name)
+    ActiveRecord::Base.connection_pool.with_connection do |db|
+      db.exec_query('create table IF NOT EXISTS fm_regions (code varchar(255) UNIQUE, name varchar(255) );')
+      CSV.read(file_name, headers: true).each do |row|
+        column_names = row.headers.map { |i| '"' + i + '"' }.join(',')
+        values = row.fields.map { |i| "'#{i}'" }.join(',')
+        db.exec_query("DELETE FROM fm_regions where code = '" + row['code'] + "' ; ")
+        db.exec_query('insert into fm_regions ( ' + column_names + ') values (' + values + ')')
+        p "FM Regions: Inserting #{values}"
+      end
+    end
+  rescue PG::Error => e
+    puts e.message
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def self.load_fm_nuts_data(directory)
+    DistributedLocks.distributed_lock(150) do
+      p "Loading NUTS static data, Environment: #{Rails.env}"
+      CCS.csv_to_nuts_regions directory + 'nuts1_regions.csv'
+      CCS.csv_to_nuts_regions directory + 'nuts2_regions.csv'
+      CCS.csv_to_nuts_regions directory + 'nuts3_regions.csv'
+      CCS.csv_to_fm_regions directory + 'regions.csv'
+      p "Finished loading NUTS codes into db #{Rails.application.config.database_configuration[Rails.env]['database']}"
+    end
+  end
+
+  def self.load_static(directory = 'data/')
+    CCS.load_fm_nuts_data directory
+  end
+end
+
+namespace :db do
+  desc 'add NUTS static data to the database'
+  task static: :environment do
+    p 'Loading NUTS static'
+    CCS.load_static
+  end
+
+  desc 'add static data to the database'
+  task setup: :static do
+  end
+end


### PR DESCRIPTION
Database schema is only used for running specs. db:migrate is not run on deployment as responsibility for this task will remain with the crown-marketplace application