### PR TITLE
FMFR-839 - Add active storage prefix

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,2 +1,3 @@
+Rails.application.config.active_storage.routes_prefix = '/legacy-storage'
 Rails.application.config.active_storage.queues.analysis = :legacy_active_storage_analysis
 Rails.application.config.active_storage.queues.purge    = :legacy_active_storage_purge


### PR DESCRIPTION
We need to add a load balancer update.
We need to add OR /legacy-storage*
This is so that documents can be downloaded properly from the admin section