### PR TITLE
Fix issue where nokogiri could not upgrade properly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,8 +304,6 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.12.5-x64-mingw32)
-      racc (~> 1.4)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
     oauth2 (1.4.7)


### PR DESCRIPTION
Before:
<img width="988" alt="Screenshot 2021-11-10 at 14 04 52" src="https://user-images.githubusercontent.com/58297459/141127375-015e662b-2908-4df6-bf0e-be75b36b20bc.png">

After:
<img width="832" alt="Screenshot 2021-11-10 at 13 59 45" src="https://user-images.githubusercontent.com/58297459/141126556-1783ddad-b69b-49f0-8e15-0f4b90f6bc31.png">
