### PR TITLE
Remove Crown Marketplace FM dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,8 +96,6 @@ gem 'role_model', '~> 0.8.2'
 gem 'sprockets', '>= 3.7.2'
 gem 'sprockets-bumble_d', '>= 2.2.0'
 
-gem 'smarter_csv'
-
 # for date layout and validation
 gem 'gov_uk_date_fields', '>= 4.2.0'
 gem 'date_validator', '>= 0.9.0'
@@ -113,9 +111,6 @@ gem 'activerecord-import', '~> 0.15.0'
 gem 'notifications-ruby-client'
 # DOCX generation
 gem 'caracal-rails', '>= 1.0.2'
-
-# duplicating procurements
-gem 'amoeba', '>= 3.1.0'
 
 # asset sync
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,6 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
-    amoeba (3.1.0)
-      activerecord (>= 3.2.6)
     asset_sync (2.15.1)
       activemodel (>= 4.1.0)
       fog-core
@@ -515,7 +513,6 @@ GEM
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
-    smarter_csv (1.2.8)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -585,7 +582,6 @@ DEPENDENCIES
   active_storage_validations (>= 0.9.5)
   activerecord-import (~> 0.15.0)
   activerecord-postgis-adapter (>= 5.2.2)
-  amoeba (>= 3.1.0)
   asset_sync
   aws-sdk-cognitoidentityprovider (~> 1.23.0)
   aws-sdk-s3 (~> 1)
@@ -649,7 +645,6 @@ DEPENDENCIES
   simplecov (>= 0.16.1)
   sinatra (~> 2.0.8, >= 2.0.8.1)
   slim (~> 4.0.1)
-  smarter_csv
   sprockets (>= 3.7.2)
   sprockets-bumble_d (>= 2.2.0)
   tzinfo-data


### PR DESCRIPTION
- Remove `smarter_csv` as this is used for downloading address which is not part of legacy
- Remove `amoeba` as this is used for dupliacting procurements which is not part of legacy