### PR TITLE
Fix flakey test issue (due to test setup)

### DIFF
--- a/spec/helpers/legal_services/suppliers_helper_spec.rb
+++ b/spec/helpers/legal_services/suppliers_helper_spec.rb
@@ -92,9 +92,9 @@ RSpec.describe LegalServices::SuppliersHelper, type: :helper do
       let(:monthly) { (Faker::Number.decimal(l_digits: 7) * 100).to_i }
 
       it 'displays the rate with pounds and pence' do
-        expect(helper.display_rate('solicitor', 'hourly')).to eq "£#{(hourly / 100.0).to_s(:delimited)}"
-        expect(helper.display_rate('solicitor', 'daily')).to eq "£#{(daily / 100.0).to_s(:delimited)}"
-        expect(helper.display_rate('solicitor', 'monthly')).to eq "£#{(monthly / 100.0).to_s(:delimited)}"
+        expect(helper.display_rate('solicitor', 'hourly')).to eq "£#{hourly.to_s[..2].to_i.to_s(:delimited)}.#{hourly.to_s[3..]}"
+        expect(helper.display_rate('solicitor', 'daily')).to eq "£#{daily.to_s[..4].to_i.to_s(:delimited)}.#{daily.to_s[5..]}"
+        expect(helper.display_rate('solicitor', 'monthly')).to eq "£#{monthly.to_s[..6].to_i.to_s(:delimited)}.#{monthly.to_s[7..]}"
       end
     end
   end


### PR DESCRIPTION
There was an issue in the spec `spec/helpers/legal_services/suppliers_helper_spec.rb:95` that if one of the rates was generated with 0 decimals (for example 75085.0 for the day rate), the expected answer would be incorrect.

The previous method would result in:
```
# daily = 7508500

"£#{(daily / 100.0).to_s(:delimited)}" => "£75,085.0"
```
Which is incorrect (note the subject of the test itself would return the correct answer "£75,085.00"

Therefore, I fixed the issue by splitting the number up and formatting exactly as we want it. Note, I didn't want to use a Rails inbuilt formatter as then we would be using the same function to both be tested and check the test.