### PR TITLE
Change to `cancancan` as `cancan` is no longer supported

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem 'sinatra', '~> 2.2.0', require: false
 gem 'slim', '~> 4.1.0'
 
 # for authorization
-gem 'cancan', '~> 1.6.10'
+gem 'cancancan', '~> 3.2.0'
 
 gem 'role_model', '~> 0.8.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
-    cancan (1.6.10)
+    cancancan (3.2.2)
     capybara (3.36.0)
       addressable
       matrix
@@ -560,7 +560,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1)
   bootsnap (>= 1.1.0)
   byebug
-  cancan (~> 1.6.10)
+  cancancan (~> 3.2.0)
   capybara (>= 3.35.3)
   caxlsx (>= 3.1.0)
   caxlsx_rails (>= 0.6.2)

--- a/app/controllers/legal_services/suppliers_controller.rb
+++ b/app/controllers/legal_services/suppliers_controller.rb
@@ -23,7 +23,7 @@ module LegalServices
         format.xlsx do
           spreadsheet_builder = LegalServices::SupplierSpreadsheetCreator.new(@suppliers, params)
           spreadsheet = spreadsheet_builder.build
-          render xlsx: spreadsheet.to_stream.read, filename: 'Shortlist of WPS Legal Services Suppliers', format: 'application/vnd.openxmlformates-officedocument.spreadsheetml.sheet'
+          send_data spreadsheet.to_stream.read, filename: 'Shortlist of WPS Legal Services Suppliers.xlsx', type: :xlsx
         end
       end
     end

--- a/app/controllers/management_consultancy/suppliers_controller.rb
+++ b/app/controllers/management_consultancy/suppliers_controller.rb
@@ -24,7 +24,7 @@ module ManagementConsultancy
         format.xlsx do
           spreadsheet_builder = ManagementConsultancy::SupplierSpreadsheetCreator.new(@all_suppliers, params)
           spreadsheet = spreadsheet_builder.build
-          render xlsx: spreadsheet.to_stream.read, filename: "shortlist_of_management_consultancy_suppliers_#{DateTime.now.getlocal.strftime '%d-%m-%Y'}", format: 'application/vnd.openxmlformates-officedocument.spreadsheetml.sheet'
+          send_data spreadsheet.to_stream.read, filename: "shortlist_of_management_consultancy_suppliers_#{DateTime.now.getlocal.strftime '%d-%m-%Y'}.xlsx", type: :xlsx
         end
       end
     end

--- a/app/controllers/supply_teachers/branches_controller.rb
+++ b/app/controllers/supply_teachers/branches_controller.rb
@@ -38,8 +38,8 @@ module SupplyTeachers
         format.html
         format.xlsx do
           spreadsheet = Spreadsheet.new(@branches, with_calculations: params[:calculations].present?)
-          filename = "Shortlist of agencies#{params[:calculations].present? ? ' (with calculator)' : ''}"
-          render xlsx: spreadsheet.to_xlsx, filename: filename
+          filename = "Shortlist of agencies#{params[:calculations].present? ? ' (with calculator)' : ''}.xlsx"
+          send_data spreadsheet.to_xlsx, filename: filename, type: :xlsx
         end
       end
     end

--- a/app/controllers/supply_teachers/downloads_controller.rb
+++ b/app/controllers/supply_teachers/downloads_controller.rb
@@ -1,14 +1,20 @@
-require 'csv'
-
 module SupplyTeachers
   class DownloadsController < SupplyTeachers::FrameworkController
+    before_action :authorize_user
+
     def index
       respond_to do |format|
         format.xlsx do
           spreadsheet = SupplyTeachers::AuditSpreadsheet.new
-          render xlsx: spreadsheet.to_xlsx, filename: 'supply_teachers'
+          send_data spreadsheet.to_xlsx, filename: 'supply_teachers.xlsx', type: :xlsx
         end
       end
+    end
+
+    protected
+
+    def authorize_user
+      authorize! :manage, SupplyTeachers::Admin::Upload
     end
   end
 end

--- a/spec/controllers/management_consultancy/suppliers_controller_spec.rb
+++ b/spec/controllers/management_consultancy/suppliers_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe ManagementConsultancy::SuppliersController, type: :controller do
       end
 
       it 'downloads the document with the right filename and file type' do
-        expect(response.headers['Content-Disposition']).to include 'filename=shortlist_of_management_consultancy_suppliers'
+        expect(response.headers['Content-Disposition']).to include 'filename="shortlist_of_management_consultancy_suppliers'
         expect(response.headers['Content-Type']).to eq 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
       end
     end

--- a/spec/controllers/supply_teachers/downloads_controller_spec.rb
+++ b/spec/controllers/supply_teachers/downloads_controller_spec.rb
@@ -10,8 +10,17 @@ RSpec.describe SupplyTeachers::DownloadsController, type: :controller do
       end
     end
 
-    context 'when logged in' do
+    context 'when logged in as a buyer' do
       login_st_buyer
+      it 'redirects to not permitted' do
+        get :index, params: { format: 'xlsx' }
+
+        expect(response).to redirect_to not_permitted_path(service: 'supply_teachers')
+      end
+    end
+
+    context 'when logged in as an admin' do
+      login_st_admin
       it 'responds to requests for xlsx files' do
         get :index, params: { format: 'xlsx' }
 


### PR DESCRIPTION
The purpose of this PR is to change from using `cancan` to `cancancan` due to the former no longer being supported anymore. as `cancancan` is based off of `cancan` we do not require any additional changes and we have tests for permissions which verify that they all still working as expected.

This led to some issues when downloading spreadsheets so I had to make a few more updates to make sure the spreadsheets can be downloaded. I was able to work out [what caused the issue](https://github.com/CanCanCommunity/cancancan/pull/495/files#diff-bc7f860bbee1c5954a600d27386afe3aa1abb5e305c7ae36c5b1f838f1f313dd) but so far have been unable to determine why it causes it.

While doing this I found that an admin file could be downloaded without the restriction that the user needed to be an admin and so I resolved that too.