### PR TITLE
Add ability to change when a framework is live through the database

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -13,3 +13,5 @@ DFE_SIGNIN_CLIENT_SECRET=client-secret
 DFE_SIGNIN_REDIRECT_URI=http://redirect.example.com
 
 CCS_APP_API_DATA_BUCKET=test
+
+RAILS_ENV_URL=http://localhost:3000

--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,9 @@ gem 'fog-aws', '>= 3.13.0'
 # Reuired for the ST import
 gem 'capybara', '>= 3.36.0'
 
+# for date layout
+gem 'gov_uk_date_fields', '>= 4.2.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,8 @@ GEM
     geocoder (1.7.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    gov_uk_date_fields (4.2.0)
+      rails (>= 5.2)
     hashdiff (1.0.1)
     hashie (5.0.0)
     highline (2.0.3)
@@ -640,6 +642,7 @@ DEPENDENCIES
   fog-aws (>= 3.13.0)
   friendly_id (~> 5.4.2)
   geocoder (>= 1.6.1)
+  gov_uk_date_fields (>= 4.2.0)
   holidays
   i18n-tasks (>= 1.0.9)
   jbuilder (~> 2.11, >= 2.11.5)

--- a/app/controllers/concerns/admin/frameworks_concern.rb
+++ b/app/controllers/concerns/admin/frameworks_concern.rb
@@ -1,0 +1,36 @@
+module Admin::FrameworksConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_framework, only: %i[edit update]
+  end
+
+  def index
+    @frameworks = Framework.public_send(service_scope)
+  end
+
+  def edit; end
+
+  def update
+    if @framework.update(framework_params)
+      redirect_to framework_index_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def set_framework
+    @framework = Framework.find(params[:id])
+  end
+
+  def framework_params
+    params.require(:framework)
+          .permit(
+            :live_at_dd,
+            :live_at_mm,
+            :live_at_yyyy,
+          )
+  end
+end

--- a/app/controllers/legal_services/admin/frameworks_controller.rb
+++ b/app/controllers/legal_services/admin/frameworks_controller.rb
@@ -1,0 +1,20 @@
+module LegalServices
+  module Admin
+    class FrameworksController < LegalServices::FrameworkController
+      include ::Admin::FrameworksConcern
+
+      before_action :authenticate_user!
+      before_action :authorize_user
+
+      def framework_index_path
+        legal_services_admin_frameworks_path
+      end
+
+      private
+
+      def authorize_user
+        authorize! :manage, LegalServices::Admin::Upload
+      end
+    end
+  end
+end

--- a/app/controllers/legal_services/framework_controller.rb
+++ b/app/controllers/legal_services/framework_controller.rb
@@ -8,5 +8,9 @@ module LegalServices
     def authorize_user
       authorize! :read, LegalServices
     end
+
+    def service_scope
+      :legal_services
+    end
   end
 end

--- a/app/controllers/management_consultancy/admin/frameworks_controller.rb
+++ b/app/controllers/management_consultancy/admin/frameworks_controller.rb
@@ -1,0 +1,20 @@
+module ManagementConsultancy
+  module Admin
+    class FrameworksController < ManagementConsultancy::FrameworkController
+      include ::Admin::FrameworksConcern
+
+      before_action :authenticate_user!
+      before_action :authorize_user
+
+      def framework_index_path
+        management_consultancy_admin_frameworks_path
+      end
+
+      private
+
+      def authorize_user
+        authorize! :manage, ManagementConsultancy::Admin::Upload
+      end
+    end
+  end
+end

--- a/app/controllers/management_consultancy/framework_controller.rb
+++ b/app/controllers/management_consultancy/framework_controller.rb
@@ -8,5 +8,9 @@ module ManagementConsultancy
     def authorize_user
       authorize! :read, ManagementConsultancy
     end
+
+    def service_scope
+      :management_consultancy
+    end
   end
 end

--- a/app/controllers/supply_teachers/admin/frameworks_controller.rb
+++ b/app/controllers/supply_teachers/admin/frameworks_controller.rb
@@ -1,0 +1,20 @@
+module SupplyTeachers
+  module Admin
+    class FrameworksController < SupplyTeachers::FrameworkController
+      include ::Admin::FrameworksConcern
+
+      before_action :authenticate_user!
+      before_action :authorize_user
+
+      def framework_index_path
+        supply_teachers_admin_frameworks_path
+      end
+
+      private
+
+      def authorize_user
+        authorize! :manage, SupplyTeachers::Admin::Upload
+      end
+    end
+  end
+end

--- a/app/controllers/supply_teachers/framework_controller.rb
+++ b/app/controllers/supply_teachers/framework_controller.rb
@@ -8,5 +8,9 @@ module SupplyTeachers
     def authorize_user
       authorize! :read, SupplyTeachers
     end
+
+    def service_scope
+      :supply_teachers
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -146,6 +146,10 @@ module ApplicationHelper
     controller.action_name == 'not_permitted'
   end
 
+  def format_date(date_object)
+    date_object&.in_time_zone('London')&.strftime '%-d %B %Y'
+  end
+
   def format_date_time(date_object)
     date_object&.in_time_zone('London')&.strftime '%e %B %Y, %l:%M%P'
   end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -1,0 +1,46 @@
+class Framework < ApplicationRecord
+  scope :supply_teachers, -> { where(service: 'supply_teachers').order(live_at: :asc) }
+  scope :management_consultancy, -> { where(service: 'management_consultancy').order(live_at: :asc) }
+  scope :legal_services, -> { where(service: 'legal_services').order(live_at: :asc) }
+
+  acts_as_gov_uk_date :live_at, error_clash_behaviour: :omit_gov_uk_date_field_error
+  validate :live_at_date_present, :live_at_date_real, on: :update
+
+  def self.frameworks
+    pluck(:framework)
+  end
+
+  def self.live_frameworks
+    where('live_at <= ?', Time.now.in_time_zone('London')).pluck(:framework)
+  end
+
+  def self.current_framework
+    live_frameworks.last
+  end
+
+  def self.current_live_framework?(framework)
+    current_framework == framework
+  end
+
+  def self.recognised_framework?(framework)
+    frameworks.include?(framework)
+  end
+
+  def status
+    if self.class.send(service).current_live_framework?(framework)
+      :live
+    else
+      live_at <= Time.now.in_time_zone('London') ? :expired : :coming
+    end
+  end
+
+  private
+
+  def live_at_date_present
+    errors.add(:live_at, :blank) if live_at_yyyy.blank? || live_at_mm.blank? || live_at_dd.blank?
+  end
+
+  def live_at_date_real
+    errors.add(:live_at, :not_a_date) unless Date.valid_date?(live_at_yyyy.to_i, live_at_mm.to_i, live_at_dd.to_i)
+  end
+end

--- a/app/views/legal_services/admin/frameworks/edit.html.erb
+++ b/app/views/legal_services/admin/frameworks/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "shared/admin/frameworks/edit", locals: { local_update_path: legal_services_admin_framework_path, local_index_path: legal_services_admin_frameworks_path, service_name: t('.service_name') } %>

--- a/app/views/legal_services/admin/frameworks/index.html.erb
+++ b/app/views/legal_services/admin/frameworks/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "shared/admin/frameworks/index", locals: { service_title: t('.service_title'), service_name: t('.service_name'), service_param: 'legal-services' } %>

--- a/app/views/management_consultancy/admin/frameworks/edit.html.erb
+++ b/app/views/management_consultancy/admin/frameworks/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "shared/admin/frameworks/edit", locals: { local_update_path: management_consultancy_admin_framework_path, local_index_path: management_consultancy_admin_frameworks_path, service_name: t('.service_name') } %>

--- a/app/views/management_consultancy/admin/frameworks/index.html.erb
+++ b/app/views/management_consultancy/admin/frameworks/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "shared/admin/frameworks/index", locals: { service_title: t('.service_title'), service_name: t('.service_name'), service_param: 'management-consultancy' } %>

--- a/app/views/shared/admin/frameworks/_edit.html.erb
+++ b/app/views/shared/admin/frameworks/_edit.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, t('.page_title').html_safe %>
+
+<%= form_with model: @framework, url: local_update_path, method: :put, local: 'false', html: { specialvalidation: true, novalidate: true } do |f| %>
+  <%= render partial: 'shared/error_summary', locals: { errors: f.object.errors } %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-!-margin-top-5">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @framework.errors[:live_at].any?%>">
+          <h1 class="govuk-label-wrapper">
+            <%= f.label :live_at, t('.update_live_at_date', framework: @framework.framework), class: "govuk-label--m"%>
+          </h1>
+          <p class="govuk-caption-m">
+            <%= t('.buyer_section_visible', current_date: Time.now.in_time_zone('London').strftime('%e/%-m/%Y'))%>
+          </p>
+          <%= display_errors(f.object, :live_at)%>
+          <%= f.gov_uk_date_field :live_at, legend_options: { page_heading: false, visually_hidden: true } %>
+        </div>
+      </div>
+
+      <%= f.submit t('.save_and_return'), class: 'govuk-button', aria: { label: t('.save_and_return')} %>
+      <p class="govuk-body">
+        <%= link_to t('.return_to_frameworks', service_name: service_name), local_index_path, class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/admin/frameworks/_index.html.erb
+++ b/app/views/shared/admin/frameworks/_index.html.erb
@@ -1,0 +1,55 @@
+<% content_for :page_title, t('.page_title', service_title: service_title) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('.page_title', service_title: service_title) %></h1>
+    <p>
+      <%= t('.this_section_allows', service_name: service_name) %>
+    </p>
+
+    <p>
+      <%= t('.if_the_framework', current_date: format_date(Time.now.in_time_zone('London'))) %>
+    </p>
+
+    <p>
+      <%= t('.the_admin_section') %>
+    </p>
+
+    <p>
+      <span class="govuk-!-font-weight-bold">
+        <%= t('.section_not_accessible') %>
+      </span>
+      <%= t('.to_update_in_prod') %>
+    </p>
+  
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header"><%= t('.framework') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.live_at') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.status') %></th>
+          <td class="govuk-table__header"></td>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @frameworks.each do |framework| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= framework.framework %></th>
+            <td class="govuk-table__cell"><%= format_date(framework.live_at) %></td>
+            <td class="govuk-table__cell">
+              <% case framework.status %>
+              <% when :live %>
+                <%= govuk_tag_with_text(:blue, t('.live')) %>
+              <% when :coming %>
+                <%= govuk_tag_with_text(:grey, t('.coming')) %>
+              <% else %>
+                <%= govuk_tag_with_text(:red, t('.expired')) %>
+              <% end %>
+            </td>
+            <td class="govuk-table__cell"><%= link_to t('.change'), "/#{service_param}/admin/frameworks/#{framework.id}/edit" %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/supply_teachers/admin/frameworks/edit.html.erb
+++ b/app/views/supply_teachers/admin/frameworks/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "shared/admin/frameworks/edit", locals: { local_update_path: supply_teachers_admin_framework_path, local_index_path: supply_teachers_admin_frameworks_path, service_name: t('.service_name') } %>

--- a/app/views/supply_teachers/admin/frameworks/index.html.erb
+++ b/app/views/supply_teachers/admin/frameworks/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "shared/admin/frameworks/index", locals: { service_title: t('.service_title'), service_name: t('.service_name'), service_param: 'supply-teachers' } %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -162,4 +162,12 @@ module Marketplace
   def self.upload_privileges?
     ENV['APP_HAS_UPLOAD_PRIVILEGES'].present?
   end
+
+  def self.rails_env_url
+    @rails_env_url ||= ENV.fetch('RAILS_ENV_URL', 'https://marketplace.service.crowncommercial.gov.uk')
+  end
+
+  def self.can_edit_legacy_frameworks?
+    @can_edit_legacy_frameworks ||= rails_env_url != 'https://marketplace.service.crowncommercial.gov.uk'
+  end
 end

--- a/config/initializers/ext.rb
+++ b/config/initializers/ext.rb
@@ -1,0 +1,1 @@
+require((Dir.glob(Rails.root) + ['/lib/ext/ruby/gov_uk_date_fields/form_fields/generate_input_fields.rb']).join)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,6 +222,11 @@ en:
   activerecord:
     errors:
       models:
+        framework:
+          attributes:
+            live_at:
+              blank: Enter a valid 'live at' date
+              not_a_date: Enter a valid 'live at' date
         legal_services/admin/upload:
           attributes:
             supplier_details_file:
@@ -572,6 +577,12 @@ en:
       ccs_logo_title: Crown Commercial Service logo
   legal_services:
     admin:
+      frameworks:
+        edit:
+          service_name: legal services
+        index:
+          service_name: legal services
+          service_title: Legal services
       passwords:
         forgot_password_confirmation:
           heading: A reset email has been sent
@@ -845,6 +856,12 @@ en:
       other: suppliers
   management_consultancy:
     admin:
+      frameworks:
+        edit:
+          service_name: management consultancy
+        index:
+          service_name: management consultancy
+          service_title: Management consultancy
       passwords:
         forgot_password_confirmation:
           heading: A reset email has been sent
@@ -1086,6 +1103,27 @@ en:
   scotland: Scotland
   shared:
     admin:
+      frameworks:
+        edit:
+          buyer_section_visible: The buyer section for this framework will be visible if the 'live at' date is today (%{current_date}) or earlier.
+          page_title: Framework 'live at' date
+          return_to_frameworks: Return to %{service_name} frameworks
+          save_and_return: Save and return
+          update_live_at_date: Update framework 'live at' date for %{framework}
+        index:
+          change: Change
+          coming: coming
+          expired: Expired
+          framework: Framework
+          if_the_framework: If the framework 'live at' date is before the current date (%{current_date}), the buyer section for this framework will be accessible to our customers.
+          live: live
+          live_at: Live at
+          page_title: "%{service_title} frameworks"
+          section_not_accessible: This section is not accessible in production and is for testing purposes only.
+          status: Status
+          the_admin_section: The admin section for a framework will always be visible for any framework that is on the system no matter when it goes live.
+          this_section_allows: This section allows you to view and change the 'live at' date for a %{service_name} framework.
+          to_update_in_prod: To update the framework 'live at' date in production speak to a developer.
       in_progress:
         checking_files: Checking files
         complete: Complete
@@ -1141,6 +1179,12 @@ en:
       other: agencies
   supply_teachers:
     admin:
+      frameworks:
+        edit:
+          service_name: supply teachers
+        index:
+          service_name: supply teachers
+          service_title: Supply teachers
       passwords:
         forgot_password_confirmation:
           heading: A reset email has been sent

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
     get '/accessibility-statement', to: 'uploads#accessibility_statement'
     get '/cookie-policy', to: 'uploads#cookie_policy'
     get '/cookie-settings', to: 'uploads#cookie_settings'
+    resources :frameworks, only: %i[index edit update] if Marketplace.can_edit_legacy_frameworks?
   end
 
   concern :admin_uploads do

--- a/db/migrate/20220404102514_create_frameworks.rb
+++ b/db/migrate/20220404102514_create_frameworks.rb
@@ -1,0 +1,11 @@
+class CreateFrameworks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :frameworks, id: :uuid do |t|
+      t.string :service, limit: 25
+      t.string :framework, limit: 6
+      t.date :live_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_03_090547) do
+ActiveRecord::Schema.define(version: 2022_04_04_102514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -35,6 +35,14 @@ ActiveRecord::Schema.define(version: 2021_09_03_090547) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "frameworks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "service", limit: 25
+    t.string "framework", limit: 6
+    t.date "live_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "legal_services_admin_uploads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/ext/ruby/gov_uk_date_fields/form_fields/generate_input_fields.rb
+++ b/lib/ext/ruby/gov_uk_date_fields/form_fields/generate_input_fields.rb
@@ -1,0 +1,15 @@
+module GovUkDateFields
+  class FormFields
+    private
+
+    def generate_input_fields
+      tag.div(class: form_group_classes) do
+        tag.fieldset(fieldset_options(@attribute, @options)) do
+          concat fieldset_legend(@attribute, @options)
+          concat hint(@attribute)
+          concat input_fields_div
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/frameworks.rake
+++ b/lib/tasks/frameworks.rake
@@ -1,0 +1,42 @@
+module Frameworks
+  def self.rm6238_live_at
+    if Rails.env.test?
+      Time.zone.now - 1.day
+    else
+      # This is not correct but it is far in the future and we can update it with another migration later on
+      Time.new(2025, 9, 1).in_time_zone('London')
+    end
+  end
+
+  def self.rm6240_live_at
+    if Rails.env.test?
+      Time.zone.now - 1.day
+    else
+      # This is not correct but it is far in the future and we can update it with another migration later on
+      Time.new(2025, 10, 1).in_time_zone('London')
+    end
+  end
+
+  def self.add_frameworks
+    ActiveRecord::Base.connection.truncate_tables(:frameworks)
+    Framework.create(service: 'supply_teachers', framework: 'RM3826', live_at: Time.new(2020, 6, 26).in_time_zone('London'))
+    Framework.create(service: 'supply_teachers', framework: 'RM6238', live_at: rm6238_live_at)
+    Framework.create(service: 'management_consultancy', framework: 'RM6187', live_at: Time.new(2021, 9, 4).in_time_zone('London'))
+    Framework.create(service: 'legal_services', framework: 'RM3788', live_at: Time.new(2020, 6, 26).in_time_zone('London'))
+    Framework.create(service: 'legal_services', framework: 'RM6240', live_at: rm6240_live_at)
+  end
+end
+
+namespace :db do
+  desc 'add the frameworks into the database'
+  task legacy_frameworks: :environment do
+    p 'Loading Legacy Frameworks'
+    DistributedLocks.distributed_lock(157) do
+      Frameworks.add_frameworks
+    end
+  end
+
+  desc 'add static data to the database'
+  task static: :legacy_frameworks do
+  end
+end

--- a/spec/controllers/legal_services/admin/frameworks_controller_spec.rb
+++ b/spec/controllers/legal_services/admin/frameworks_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe LegalServices::Admin::FrameworksController do
+  let(:default_params) { { service: 'legal_services/admin' } }
+
+  login_ls_admin
+
+  describe 'GET index' do
+    it 'renders the index page' do
+      get :index
+      expect(response).to render_template(:index)
+    end
+
+    context 'when logged in as a buyer' do
+      login_ls_buyer
+
+      it 'redirects to not permitted' do
+        get :index
+        expect(response).to redirect_to not_permitted_path(service: 'legal_services')
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    let(:framework) { create(:legacy_framework) }
+
+    it 'renders the edit page' do
+      get :edit, params: { id: framework.id }
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'POST update' do
+    let(:framework) { create(:legacy_framework) }
+    let(:live_at_yyyy) { framework.live_at.year.to_s }
+    let(:live_at_mm) { framework.live_at.month.to_s }
+    let(:live_at_dd) { framework.live_at.day.to_s }
+
+    before { post :update, params: { id: framework.id, framework: { live_at_dd: live_at_dd, live_at_mm: live_at_mm, live_at_yyyy: live_at_yyyy } } }
+
+    context 'when the data is valid' do
+      it 'redirects to legal_services_admin_frameworks_path' do
+        expect(response).to redirect_to legal_services_admin_frameworks_path
+      end
+    end
+
+    context 'when the data is invalid' do
+      let(:live_at_mm) { '13' }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/management_consultancy/admin/frameworks_controller_spec.rb
+++ b/spec/controllers/management_consultancy/admin/frameworks_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe ManagementConsultancy::Admin::FrameworksController do
+  let(:default_params) { { service: 'management_consultancy/admin' } }
+
+  login_mc_admin
+
+  describe 'GET index' do
+    it 'renders the index page' do
+      get :index
+      expect(response).to render_template(:index)
+    end
+
+    context 'when logged in as a buyer' do
+      login_mc_buyer
+
+      it 'redirects to not permitted' do
+        get :index
+        expect(response).to redirect_to not_permitted_path(service: 'management_consultancy')
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    let(:framework) { create(:legacy_framework) }
+
+    it 'renders the edit page' do
+      get :edit, params: { id: framework.id }
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'POST update' do
+    let(:framework) { create(:legacy_framework) }
+    let(:live_at_yyyy) { framework.live_at.year.to_s }
+    let(:live_at_mm) { framework.live_at.month.to_s }
+    let(:live_at_dd) { framework.live_at.day.to_s }
+
+    before { post :update, params: { id: framework.id, framework: { live_at_dd: live_at_dd, live_at_mm: live_at_mm, live_at_yyyy: live_at_yyyy } } }
+
+    context 'when the data is valid' do
+      it 'redirects to management_consultancy_admin_frameworks_path' do
+        expect(response).to redirect_to management_consultancy_admin_frameworks_path
+      end
+    end
+
+    context 'when the data is invalid' do
+      let(:live_at_mm) { '13' }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/supply_teachers/admin/frameworks_controller_spec.rb
+++ b/spec/controllers/supply_teachers/admin/frameworks_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe SupplyTeachers::Admin::FrameworksController do
+  let(:default_params) { { service: 'supply_teachers/admin' } }
+
+  login_st_admin
+
+  describe 'GET index' do
+    it 'renders the index page' do
+      get :index
+      expect(response).to render_template(:index)
+    end
+
+    context 'when logged in as a buyer' do
+      login_st_buyer
+
+      it 'redirects to not permitted' do
+        get :index
+        expect(response).to redirect_to not_permitted_path(service: 'supply_teachers')
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    let(:framework) { create(:legacy_framework) }
+
+    it 'renders the edit page' do
+      get :edit, params: { id: framework.id }
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'POST update' do
+    let(:framework) { create(:legacy_framework) }
+    let(:live_at_yyyy) { framework.live_at.year.to_s }
+    let(:live_at_mm) { framework.live_at.month.to_s }
+    let(:live_at_dd) { framework.live_at.day.to_s }
+
+    before { post :update, params: { id: framework.id, framework: { live_at_dd: live_at_dd, live_at_mm: live_at_mm, live_at_yyyy: live_at_yyyy } } }
+
+    context 'when the data is valid' do
+      it 'redirects to supply_teachers_admin_frameworks_path' do
+        expect(response).to redirect_to supply_teachers_admin_frameworks_path
+      end
+    end
+
+    context 'when the data is invalid' do
+      let(:live_at_mm) { '13' }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/factories/frameworks.rb
+++ b/spec/factories/frameworks.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :legacy_framework, class: 'Framework' do
+    id { SecureRandom.uuid }
+    service { ('a'..'z').to_a.sample(8).join }
+    framework { "FK#{Array.new(4) { rand(10) }.join}" }
+    live_at { Time.zone.now + 1.year }
+  end
+end

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -1,0 +1,525 @@
+require 'rails_helper'
+
+RSpec.describe Framework, type: :model do
+  describe '.frameworks' do
+    context 'when no scope is provided' do
+      it 'returns RM3826, RM6238, RM6187 and RM3788' do
+        expect(described_class.frameworks).to eq %w[RM3826 RM6238 RM6187 RM3788 RM6240]
+      end
+    end
+
+    context 'when the supply_teachers scope is provided' do
+      it 'returns RM3826 and RM6238' do
+        expect(described_class.supply_teachers.frameworks).to eq %w[RM3826 RM6238]
+      end
+    end
+
+    context 'when the management_consultancy scope is provided' do
+      it 'returns RM6187' do
+        expect(described_class.management_consultancy.frameworks).to eq %w[RM6187]
+      end
+    end
+
+    context 'when the legal_services scope is provided' do
+      it 'returns RM3788' do
+        expect(described_class.legal_services.frameworks).to eq %w[RM3788 RM6240]
+      end
+    end
+  end
+
+  shared_context 'and RM6238 is live in the future' do
+    before { described_class.find_by(framework: 'RM6238').update(live_at: Time.zone.now + 1.day) }
+  end
+
+  shared_context 'and RM6238 is live today' do
+    before { described_class.find_by(framework: 'RM6238').update(live_at: Time.zone.now) }
+  end
+
+  shared_context 'and RM6240 is live in the future' do
+    before { described_class.find_by(framework: 'RM6240').update(live_at: Time.zone.now + 1.day) }
+  end
+
+  shared_context 'and RM6240 is live today' do
+    before { described_class.find_by(framework: 'RM6240').update(live_at: Time.zone.now) }
+  end
+
+  describe '.live_frameworks' do
+    context 'when RM6238 goes live tomorrow' do
+      include_context 'and RM6238 is live in the future'
+
+      it 'returns RM3826, RM6187, RM3788 and RM6240' do
+        expect(described_class.live_frameworks).to eq %w[RM3826 RM6187 RM3788 RM6240]
+      end
+
+      context 'and the supply_teachers scope is provided' do
+        it 'returns RM3826' do
+          expect(described_class.supply_teachers.live_frameworks).to eq %w[RM3826]
+        end
+      end
+    end
+
+    context 'when RM6240 goes live tomorrow' do
+      include_context 'and RM6240 is live in the future'
+
+      it 'returns RM3826, RM6238, RM6187 and RM3788, ' do
+        expect(described_class.live_frameworks).to eq %w[RM3826 RM6238 RM6187 RM3788]
+      end
+
+      context 'and the legal_services scope is provided' do
+        it 'returns RM3788' do
+          expect(described_class.legal_services.live_frameworks).to eq %w[RM3788]
+        end
+      end
+    end
+
+    context 'when RM6238 is live today' do
+      include_context 'and RM6238 is live today'
+
+      it 'returns RM3826, RM6238, RM6187, RM6240 and RM3788' do
+        expect(described_class.live_frameworks).to eq %w[RM3826 RM6187 RM3788 RM6240 RM6238]
+      end
+
+      context 'and the supply_teachers scope is provided' do
+        it 'returns RM3826 and RM6238' do
+          expect(described_class.supply_teachers.live_frameworks).to eq %w[RM3826 RM6238]
+        end
+      end
+    end
+
+    context 'when RM6240 is live today' do
+      include_context 'and RM6240 is live today'
+
+      it 'returns RM3826, RM6238, RM6187, RM3788 and RM6240' do
+        expect(described_class.live_frameworks).to eq %w[RM3826 RM6238 RM6187 RM3788 RM6240]
+      end
+
+      context 'and the legal_services scope is provided' do
+        it 'returns RM3788 and RM6240' do
+          expect(described_class.legal_services.live_frameworks).to eq %w[RM3788 RM6240]
+        end
+      end
+    end
+
+    context 'when RM6238 went live yesterday' do
+      it 'returns RM3826, RM6238, RM6187, RM3788 and RM6240' do
+        expect(described_class.live_frameworks).to eq %w[RM3826 RM6238 RM6187 RM3788 RM6240]
+      end
+
+      context 'and the supply_teachers scope is provided' do
+        it 'returns RM3826 and RM6238' do
+          expect(described_class.supply_teachers.live_frameworks).to eq %w[RM3826 RM6238]
+        end
+      end
+    end
+
+    context 'when RM6240 went live yesterday' do
+      it 'returns RM3826, RM6240, RM6187, RM3788 and RM6240' do
+        expect(described_class.live_frameworks).to eq %w[RM3826 RM6238 RM6187 RM3788 RM6240]
+      end
+
+      context 'and the legal_services scope is provided' do
+        it 'returns RM3788 and RM6240' do
+          expect(described_class.legal_services.live_frameworks).to eq %w[RM3788 RM6240]
+        end
+      end
+    end
+  end
+
+  describe '.current_framework' do
+    context 'when the supply_teachers scope is provided' do
+      context 'when RM6238 goes live tomorrow' do
+        include_context 'and RM6238 is live in the future'
+
+        it 'returns RM3826' do
+          expect(described_class.supply_teachers.current_framework).to eq 'RM3826'
+        end
+      end
+
+      context 'when RM6238 is live today' do
+        include_context 'and RM6238 is live today'
+
+        it 'returns RM6238' do
+          expect(described_class.supply_teachers.current_framework).to eq 'RM6238'
+        end
+      end
+
+      context 'when RM6238 went live yesterday' do
+        it 'returns RM6238' do
+          expect(described_class.supply_teachers.current_framework).to eq 'RM6238'
+        end
+      end
+    end
+
+    context 'when the management_consultancy scope is provided' do
+      it 'returns RM6187' do
+        expect(described_class.management_consultancy.current_framework).to eq 'RM6187'
+      end
+    end
+
+    context 'when the legal_services scope is provided' do
+      context 'when RM6240 goes live tomorrow' do
+        include_context 'and RM6240 is live in the future'
+
+        it 'returns RM3788' do
+          expect(described_class.legal_services.current_framework).to eq 'RM3788'
+        end
+      end
+
+      context 'when RM6240 is live today' do
+        include_context 'and RM6240 is live today'
+
+        it 'returns RM6240' do
+          expect(described_class.legal_services.current_framework).to eq 'RM6240'
+        end
+      end
+
+      context 'when RM6240 went live yesterday' do
+        it 'returns RM6240' do
+          expect(described_class.legal_services.current_framework).to eq 'RM6240'
+        end
+      end
+    end
+  end
+
+  # rubocop:disable RSpec/NestedGroups
+  describe '.current_live_framework?' do
+    context 'when the supply_teachers scope is provided' do
+      let(:result) { described_class.supply_teachers.current_live_framework?(framework) }
+
+      context 'when the framework passed is RM3826' do
+        let(:framework) { 'RM3826' }
+
+        context 'and RM6238 goes live tomorrow' do
+          include_context 'and RM6238 is live in the future'
+
+          it 'returns true' do
+            expect(result).to be true
+          end
+        end
+
+        context 'when RM6238 is live today' do
+          include_context 'and RM6238 is live today'
+
+          it 'returns false' do
+            expect(result).to be false
+          end
+        end
+
+        context 'and RM6238 went live yesterday' do
+          it 'returns false' do
+            expect(result).to be false
+          end
+        end
+      end
+
+      context 'when the framework passed is RM6238' do
+        let(:framework) { 'RM6238' }
+
+        context 'and RM6238 goes live tomorrow' do
+          include_context 'and RM6238 is live in the future'
+
+          it 'returns false' do
+            expect(result).to be false
+          end
+        end
+
+        context 'when RM6238 is live today' do
+          include_context 'and RM6238 is live today'
+
+          it 'returns true' do
+            expect(result).to be true
+          end
+        end
+
+        context 'and RM6238 went live yesterday' do
+          it 'returns true' do
+            expect(result).to be true
+          end
+        end
+      end
+
+      context 'when the framework is neither RM3826 or RM6238' do
+        let(:framework) { 'RM6187' }
+
+        it 'returns false' do
+          expect(result).to be false
+        end
+      end
+    end
+
+    context 'when the management_consultancy scope is provided' do
+      context 'when the framework is RM6187' do
+        it 'returns true' do
+          expect(described_class.management_consultancy.current_live_framework?('RM6187')).to be true
+        end
+      end
+
+      context 'when the framework is not RM6187' do
+        it 'returns false' do
+          expect(described_class.management_consultancy.current_live_framework?('RM3788')).to be false
+        end
+      end
+    end
+
+    context 'when the legal_services scope is provided' do
+      let(:result) { described_class.legal_services.current_live_framework?(framework) }
+
+      context 'when the framework passed is RM3788' do
+        let(:framework) { 'RM3788' }
+
+        context 'and RM6240 goes live tomorrow' do
+          include_context 'and RM6240 is live in the future'
+
+          it 'returns true' do
+            expect(result).to be true
+          end
+        end
+
+        context 'when RM6240 is live today' do
+          include_context 'and RM6240 is live today'
+
+          it 'returns false' do
+            expect(result).to be false
+          end
+        end
+
+        context 'and RM6240 went live yesterday' do
+          it 'returns false' do
+            expect(result).to be false
+          end
+        end
+      end
+
+      context 'when the framework passed is RM6240' do
+        let(:framework) { 'RM6240' }
+
+        context 'and RM6240 goes live tomorrow' do
+          include_context 'and RM6240 is live in the future'
+
+          it 'returns false' do
+            expect(result).to be false
+          end
+        end
+
+        context 'when RM6240 is live today' do
+          include_context 'and RM6240 is live today'
+
+          it 'returns true' do
+            expect(result).to be true
+          end
+        end
+
+        context 'and RM6240 went live yesterday' do
+          it 'returns true' do
+            expect(result).to be true
+          end
+        end
+      end
+
+      context 'when the framework is neither RM3788 or RM6240' do
+        let(:framework) { 'RM6187' }
+
+        it 'returns false' do
+          expect(result).to be false
+        end
+      end
+    end
+  end
+
+  describe '.status' do
+    let(:result) { described_class.find_by(framework: framework).status }
+
+    context 'when considering supply_teacher frameworks' do
+      context 'when the framework passed is RM3826' do
+        context 'and RM6238 goes live tomorrow' do
+          include_context 'and RM6238 is live in the future'
+
+          context 'and the frameworks is RM3826' do
+            let(:framework) { 'RM3826' }
+
+            it 'returns live' do
+              expect(result).to eq :live
+            end
+          end
+
+          context 'and the frameworks is RM6238' do
+            let(:framework) { 'RM6238' }
+
+            it 'returns coming' do
+              expect(result).to eq :coming
+            end
+          end
+        end
+
+        context 'when RM6238 is live today' do
+          include_context 'and RM6238 is live today'
+
+          context 'and the frameworks is RM3826' do
+            let(:framework) { 'RM3826' }
+
+            it 'returns expired' do
+              expect(result).to eq :expired
+            end
+          end
+
+          context 'and the frameworks is RM6238' do
+            let(:framework) { 'RM6238' }
+
+            it 'returns live' do
+              expect(result).to eq :live
+            end
+          end
+        end
+
+        context 'and RM6238 went live yesterday' do
+          context 'and the frameworks is RM3826' do
+            let(:framework) { 'RM3826' }
+
+            it 'returns expired' do
+              expect(result).to eq :expired
+            end
+          end
+
+          context 'and the frameworks is RM6238' do
+            let(:framework) { 'RM6238' }
+
+            it 'returns live' do
+              expect(result).to eq :live
+            end
+          end
+        end
+      end
+    end
+
+    context 'when considering management_consultancy frameworks' do
+      let(:framework) { 'RM6187' }
+
+      it 'returns live' do
+        expect(result).to eq :live
+      end
+    end
+
+    context 'when considering legal_services frameworks' do
+      context 'when the framework passed is RM3788' do
+        context 'and RM6240 goes live tomorrow' do
+          include_context 'and RM6240 is live in the future'
+
+          context 'and the frameworks is RM3788' do
+            let(:framework) { 'RM3788' }
+
+            it 'returns live' do
+              expect(result).to eq :live
+            end
+          end
+
+          context 'and the frameworks is RM6240' do
+            let(:framework) { 'RM6240' }
+
+            it 'returns coming' do
+              expect(result).to eq :coming
+            end
+          end
+        end
+
+        context 'when RM6240 is live today' do
+          include_context 'and RM6240 is live today'
+
+          context 'and the frameworks is RM3788' do
+            let(:framework) { 'RM3788' }
+
+            it 'returns expired' do
+              expect(result).to eq :expired
+            end
+          end
+
+          context 'and the frameworks is RM6240' do
+            let(:framework) { 'RM6240' }
+
+            it 'returns live' do
+              expect(result).to eq :live
+            end
+          end
+        end
+
+        context 'and RM6240 went live yesterday' do
+          context 'and the frameworks is RM3788' do
+            let(:framework) { 'RM3788' }
+
+            it 'returns expired' do
+              expect(result).to eq :expired
+            end
+          end
+
+          context 'and the frameworks is RM6240' do
+            let(:framework) { 'RM6240' }
+
+            it 'returns live' do
+              expect(result).to eq :live
+            end
+          end
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/NestedGroups
+
+  describe 'validating the live at date' do
+    let(:framework) { create(:legacy_framework) }
+    let(:live_at) { Time.zone.now + 1.day }
+    let(:live_at_yyyy) { live_at.year.to_s }
+    let(:live_at_mm) { live_at.month.to_s }
+    let(:live_at_dd) { live_at.day.to_s }
+
+    before do
+      framework.live_at_yyyy = live_at_yyyy
+      framework.live_at_mm = live_at_mm
+      framework.live_at_dd = live_at_dd
+    end
+
+    context 'when considering live_at_yyyy and it is nil' do
+      let(:live_at_yyyy) { nil }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:live_at].first).to eq 'Enter a valid \'live at\' date'
+      end
+    end
+
+    context 'when considering live_at_mm and it is blank' do
+      let(:live_at_mm) { '' }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:live_at].first).to eq 'Enter a valid \'live at\' date'
+      end
+    end
+
+    context 'when considering live_at_dd and it is empty' do
+      let(:live_at_dd) { '    ' }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:live_at].first).to eq 'Enter a valid \'live at\' date'
+      end
+    end
+
+    context 'when considering the full live_at' do
+      context 'and it is not a real date' do
+        let(:live_at_yyyy) { live_at.year.to_s }
+        let(:live_at_mm) { '2' }
+        let(:live_at_dd) { '30' }
+
+        it 'is not valid and has the correct error message' do
+          expect(framework.valid?(:update)).to eq false
+          expect(framework.errors[:live_at].first).to eq 'Enter a valid \'live at\' date'
+        end
+      end
+
+      context 'and it is a real date' do
+        it 'is valid' do
+          expect(framework.valid?(:update)).to eq true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Similar to work done in Facilities Management, I’ve created a table that has the service frameworks hosted on the legacy system.
It is identical to FM except there is an additional `service` attribute to distinguish between the legacy services.

I then created the pages so an admin user in the lower environments can change them if necessary.
However, this data does not do anything to the services yet but is prerequisite for future work.

We also need to create the environment variable `/Environment/global/RAILS_ENV_URL` which means we can delete the duplicate variables:
- `/Environment/ccs/cmp-legacy/RAILS_ENV_URL`
- `/Environment/ccs/cmp/RAILS_ENV_URL`
- `/Environment/ccs/cmpsidekiq/RAILS_ENV_URL`
- `/Environment/ccs/legacy-skiq/RAILS_ENV_URL`

The value for `/Environment/global/RAILS_ENV_URL` in each environment will be:
Environment | Value
--|--
sandbox | `https://cmp.cmp-sandbox.crowncommercial.gov.uk`
cmpdev | `https://cmp.cmpdev.crowncommercial.gov.uk`
preview | `https://marketplace.preview.crowncommercial.gov.uk`
production | `https://marketplace.service.crowncommercial.gov.uk`

We also need to update the following environment variables:
Variable | Value
--|--
`/Environment/ccs/cmp-legacy/APP_RUN_RAKE_TASKS` | `TRUE`
`/Environment/ccs/cmp-legacy/RAKE_TASK_LIST` | `db:legacy_frameworks`
