### PR TITLE
Fix issue where users can't reset their password

### DIFF
--- a/app/views/management_consultancy/rm6187/passwords/new.html.erb
+++ b/app/views/management_consultancy/rm6187/passwords/new.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'shared/passwords/new', locals: { local_new_path: management_consultancy_users_password_path }%>
+<%= render partial: 'shared/passwords/new', locals: { local_new_path: management_consultancy_rm6187_users_password_path }%>

--- a/spec/controllers/legal_services/rm3788/admin/passwords_controller_spec.rb
+++ b/spec/controllers/legal_services/rm3788/admin/passwords_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe LegalServices::RM3788::Admin::PasswordsController, type: :control
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end
@@ -50,6 +52,8 @@ RSpec.describe LegalServices::RM3788::Admin::PasswordsController, type: :control
       cookies[:crown_marketplace_reset_email] = 'test@email.com'
       get :edit
     end
+
+    render_views
 
     it 'renders the edit page' do
       expect(response).to render_template(:edit)
@@ -98,6 +102,8 @@ RSpec.describe LegalServices::RM3788::Admin::PasswordsController, type: :control
 
   describe 'GET password_reset_success' do
     before { get :password_reset_success }
+
+    render_views
 
     it 'renders the password_reset_success page' do
       expect(response).to render_template(:password_reset_success)

--- a/spec/controllers/legal_services/rm3788/admin/sessions_controller_spec.rb
+++ b/spec/controllers/legal_services/rm3788/admin/sessions_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe LegalServices::RM3788::Admin::SessionsController, type: :controll
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end

--- a/spec/controllers/legal_services/rm3788/passwords_controller_spec.rb
+++ b/spec/controllers/legal_services/rm3788/passwords_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe LegalServices::RM3788::PasswordsController, type: :controller do
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end
@@ -50,6 +52,8 @@ RSpec.describe LegalServices::RM3788::PasswordsController, type: :controller do
       cookies[:crown_marketplace_reset_email] = 'test@email.com'
       get :edit
     end
+
+    render_views
 
     it 'renders the edit page' do
       expect(response).to render_template(:edit)
@@ -98,6 +102,8 @@ RSpec.describe LegalServices::RM3788::PasswordsController, type: :controller do
 
   describe 'GET password_reset_success' do
     before { get :password_reset_success }
+
+    render_views
 
     it 'renders the password_reset_success page' do
       expect(response).to render_template(:password_reset_success)

--- a/spec/controllers/legal_services/rm3788/registrations_controller_spec.rb
+++ b/spec/controllers/legal_services/rm3788/registrations_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe LegalServices::RM3788::RegistrationsController, type: :controller
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end
@@ -61,6 +63,8 @@ RSpec.describe LegalServices::RM3788::RegistrationsController, type: :controller
 
   describe 'GET domain_not_on_safelist' do
     before { get :domain_not_on_safelist }
+
+    render_views
 
     it 'renders the new page' do
       expect(response).to render_template(:domain_not_on_safelist)

--- a/spec/controllers/legal_services/rm3788/sessions_controller_spec.rb
+++ b/spec/controllers/legal_services/rm3788/sessions_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe LegalServices::RM3788::SessionsController, type: :controller do
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end

--- a/spec/controllers/legal_services/rm3788/users_controller_spec.rb
+++ b/spec/controllers/legal_services/rm3788/users_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe LegalServices::RM3788::UsersController, type: :controller do
   describe 'GET confirm_new' do
     before { get :confirm_new }
 
+    render_views
+
     it 'renders the confirm_new page' do
       expect(response).to render_template(:confirm_new)
     end

--- a/spec/controllers/management_consultancy/rm6187/admin/passwords_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/admin/passwords_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::PasswordsController, type: 
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end
@@ -50,6 +52,8 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::PasswordsController, type: 
       cookies[:crown_marketplace_reset_email] = 'test@email.com'
       get :edit
     end
+
+    render_views
 
     it 'renders the edit page' do
       expect(response).to render_template(:edit)
@@ -98,6 +102,8 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::PasswordsController, type: 
 
   describe 'GET password_reset_success' do
     before { get :password_reset_success }
+
+    render_views
 
     it 'renders the password_reset_success page' do
       expect(response).to render_template(:password_reset_success)

--- a/spec/controllers/management_consultancy/rm6187/admin/sessions_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/admin/sessions_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::SessionsController, type: :
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end

--- a/spec/controllers/management_consultancy/rm6187/admin/users_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/admin/users_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::UsersController, type: :con
   describe 'GET challenge_new' do
     let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
 
+    render_views
+
     before do
       cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
       get :challenge_new, params: { challenge_name: challenge_name }

--- a/spec/controllers/management_consultancy/rm6187/passwords_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/passwords_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe ManagementConsultancy::RM6187::PasswordsController, type: :contro
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end
@@ -50,6 +52,8 @@ RSpec.describe ManagementConsultancy::RM6187::PasswordsController, type: :contro
       cookies[:crown_marketplace_reset_email] = 'test@email.com'
       get :edit
     end
+
+    render_views
 
     it 'renders the edit page' do
       expect(response).to render_template(:edit)
@@ -98,6 +102,8 @@ RSpec.describe ManagementConsultancy::RM6187::PasswordsController, type: :contro
 
   describe 'GET password_reset_success' do
     before { get :password_reset_success }
+
+    render_views
 
     it 'renders the password_reset_success page' do
       expect(response).to render_template(:password_reset_success)

--- a/spec/controllers/management_consultancy/rm6187/registrations_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/registrations_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe ManagementConsultancy::RM6187::RegistrationsController, type: :co
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end
@@ -61,6 +63,8 @@ RSpec.describe ManagementConsultancy::RM6187::RegistrationsController, type: :co
 
   describe 'GET domain_not_on_safelist' do
     before { get :domain_not_on_safelist }
+
+    render_views
 
     it 'renders the new page' do
       expect(response).to render_template(:domain_not_on_safelist)

--- a/spec/controllers/management_consultancy/rm6187/sessions_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/sessions_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe ManagementConsultancy::RM6187::SessionsController, type: :control
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end

--- a/spec/controllers/management_consultancy/rm6187/users_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/users_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe ManagementConsultancy::RM6187::UsersController, type: :controller
   describe 'GET confirm_new' do
     before { get :confirm_new }
 
+    render_views
+
     it 'renders the confirm_new page' do
       expect(response).to render_template(:confirm_new)
     end

--- a/spec/controllers/supply_teachers/rm3826/admin/passwords_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm3826/admin/passwords_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe SupplyTeachers::RM3826::Admin::PasswordsController, type: :contro
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end
@@ -50,6 +52,8 @@ RSpec.describe SupplyTeachers::RM3826::Admin::PasswordsController, type: :contro
       cookies[:crown_marketplace_reset_email] = 'test@email.com'
       get :edit
     end
+
+    render_views
 
     it 'renders the edit page' do
       expect(response).to render_template(:edit)
@@ -98,6 +102,8 @@ RSpec.describe SupplyTeachers::RM3826::Admin::PasswordsController, type: :contro
 
   describe 'GET password_reset_success' do
     before { get :password_reset_success }
+
+    render_views
 
     it 'renders the password_reset_success page' do
       expect(response).to render_template(:password_reset_success)

--- a/spec/controllers/supply_teachers/rm3826/admin/sessions_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm3826/admin/sessions_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe SupplyTeachers::RM3826::Admin::SessionsController, type: :control
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end

--- a/spec/controllers/supply_teachers/rm3826/passwords_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm3826/passwords_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe SupplyTeachers::RM3826::PasswordsController, type: :controller do
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end
@@ -50,6 +52,8 @@ RSpec.describe SupplyTeachers::RM3826::PasswordsController, type: :controller do
       cookies[:crown_marketplace_reset_email] = 'test@email.com'
       get :edit
     end
+
+    render_views
 
     it 'renders the edit page' do
       expect(response).to render_template(:edit)
@@ -98,6 +102,8 @@ RSpec.describe SupplyTeachers::RM3826::PasswordsController, type: :controller do
 
   describe 'GET password_reset_success' do
     before { get :password_reset_success }
+
+    render_views
 
     it 'renders the password_reset_success page' do
       expect(response).to render_template(:password_reset_success)

--- a/spec/controllers/supply_teachers/rm3826/sessions_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm3826/sessions_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe SupplyTeachers::RM3826::SessionsController, type: :controller do
   describe 'GET new' do
     before { get :new }
 
+    render_views
+
     it 'renders the new page' do
       expect(response).to render_template(:new)
     end


### PR DESCRIPTION
This was spotted on Rollbar: https://rollbar.com/crowncommercial/Digital-Foundation/items/969/?utm_campaign=new_item&utm_medium=email&utm_source=rollbar-notification&utm_content=control

Fix issue where users can't reset their password and add tests to make sure it has worked