### PR TITLE
FMFR-1224 - Allow multiple frameworks to be live at once

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   class UnrecognisedFrameworkError < StandardError; end
+  class UnrecognisedLiveFrameworkError < StandardError; end
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery with: :exception

--- a/app/controllers/concerns/admin/frameworks_concern.rb
+++ b/app/controllers/concerns/admin/frameworks_concern.rb
@@ -32,6 +32,9 @@ module Admin::FrameworksConcern
             :live_at_dd,
             :live_at_mm,
             :live_at_yyyy,
+            :expires_at_dd,
+            :expires_at_mm,
+            :expires_at_yyyy,
           )
   end
 end

--- a/app/controllers/legal_services/framework_controller.rb
+++ b/app/controllers/legal_services/framework_controller.rb
@@ -2,7 +2,14 @@ module LegalServices
   class FrameworkController < ::ApplicationController
     before_action :authenticate_user!
     before_action :authorize_user
-    before_action :redirect_if_not_live_framework
+    before_action :raise_if_not_live_framework
+
+    rescue_from UnrecognisedLiveFrameworkError do
+      @unrecognised_framework = params[:framework]
+      params[:framework] = Framework.legal_services.current_framework
+
+      render 'legal_services/home/unrecognised_framework', status: :bad_request
+    end
 
     protected
 
@@ -10,8 +17,8 @@ module LegalServices
       authorize! :read, LegalServices
     end
 
-    def redirect_if_not_live_framework
-      redirect_to legal_services_path unless Framework.legal_services.current_live_framework?(params[:framework])
+    def raise_if_not_live_framework
+      raise UnrecognisedLiveFrameworkError, 'Unrecognised Live Framework' unless Framework.legal_services.live_framework?(params[:framework])
     end
   end
 end

--- a/app/controllers/legal_services/home_controller.rb
+++ b/app/controllers/legal_services/home_controller.rb
@@ -1,13 +1,12 @@
 module LegalServices
   class HomeController < LegalServices::FrameworkController
-    before_action :authenticate_user!, :authorize_user, :redirect_if_not_live_framework, except: %i[framework index]
+    before_action :authenticate_user!, :authorize_user, except: %i[framework index]
+    before_action :raise_if_not_live_framework, except: :framework
 
     def framework
       redirect_to legal_services_index_path(Framework.legal_services.current_framework)
     end
 
-    def index
-      redirect_if_not_live_framework
-    end
+    def index; end
   end
 end

--- a/app/controllers/management_consultancy/framework_controller.rb
+++ b/app/controllers/management_consultancy/framework_controller.rb
@@ -2,7 +2,14 @@ module ManagementConsultancy
   class FrameworkController < ::ApplicationController
     before_action :authenticate_user!
     before_action :authorize_user
-    before_action :redirect_if_not_live_framework
+    before_action :raise_if_not_live_framework
+
+    rescue_from UnrecognisedLiveFrameworkError do
+      @unrecognised_framework = params[:framework]
+      params[:framework] = Framework.management_consultancy.current_framework
+
+      render 'management_consultancy/home/unrecognised_framework', status: :bad_request
+    end
 
     protected
 
@@ -10,8 +17,8 @@ module ManagementConsultancy
       authorize! :read, ManagementConsultancy
     end
 
-    def redirect_if_not_live_framework
-      redirect_to management_consultancy_path unless Framework.management_consultancy.current_live_framework?(params[:framework])
+    def raise_if_not_live_framework
+      raise UnrecognisedLiveFrameworkError, 'Unrecognised Live Framework' unless Framework.management_consultancy.live_framework?(params[:framework])
     end
   end
 end

--- a/app/controllers/management_consultancy/home_controller.rb
+++ b/app/controllers/management_consultancy/home_controller.rb
@@ -1,13 +1,12 @@
 module ManagementConsultancy
   class HomeController < ManagementConsultancy::FrameworkController
-    before_action :authenticate_user!, :authorize_user, :redirect_if_not_live_framework, except: %i[framework index]
+    before_action :authenticate_user!, :authorize_user, except: %i[framework index]
+    before_action :raise_if_not_live_framework, except: :framework
 
     def framework
       redirect_to management_consultancy_index_path(Framework.management_consultancy.current_framework)
     end
 
-    def index
-      redirect_if_not_live_framework
-    end
+    def index; end
   end
 end

--- a/app/controllers/supply_teachers/framework_controller.rb
+++ b/app/controllers/supply_teachers/framework_controller.rb
@@ -2,7 +2,14 @@ module SupplyTeachers
   class FrameworkController < ::ApplicationController
     before_action :authenticate_user!
     before_action :authorize_user
-    before_action :redirect_if_not_live_framework
+    before_action :raise_if_not_live_framework
+
+    rescue_from UnrecognisedLiveFrameworkError do
+      @unrecognised_framework = params[:framework]
+      params[:framework] = Framework.supply_teachers.current_framework
+
+      render 'supply_teachers/home/unrecognised_framework', status: :bad_request
+    end
 
     protected
 
@@ -10,8 +17,8 @@ module SupplyTeachers
       authorize! :read, SupplyTeachers
     end
 
-    def redirect_if_not_live_framework
-      redirect_to supply_teachers_path unless Framework.supply_teachers.current_live_framework?(params[:framework])
+    def raise_if_not_live_framework
+      raise UnrecognisedLiveFrameworkError, 'Unrecognised Live Framework' unless Framework.supply_teachers.live_framework?(params[:framework])
     end
   end
 end

--- a/app/controllers/supply_teachers/home_controller.rb
+++ b/app/controllers/supply_teachers/home_controller.rb
@@ -1,13 +1,12 @@
 module SupplyTeachers
   class HomeController < SupplyTeachers::FrameworkController
-    before_action :authenticate_user!, :authorize_user, :redirect_if_not_live_framework, except: %i[framework index]
+    before_action :authenticate_user!, :authorize_user, except: %i[framework index]
+    before_action :raise_if_not_live_framework, except: :framework
 
     def framework
       redirect_to supply_teachers_index_path(Framework.supply_teachers.current_framework)
     end
 
-    def index
-      redirect_if_not_live_framework
-    end
+    def index; end
   end
 end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -3,23 +3,24 @@ class Framework < ApplicationRecord
   scope :management_consultancy, -> { where(service: 'management_consultancy').order(live_at: :asc) }
   scope :legal_services, -> { where(service: 'legal_services').order(live_at: :asc) }
 
-  acts_as_gov_uk_date :live_at, error_clash_behaviour: :omit_gov_uk_date_field_error
-  validate :live_at_date_present, :live_at_date_real, on: :update
+  acts_as_gov_uk_date :live_at, :expires_at, error_clash_behaviour: :omit_gov_uk_date_field_error
+
+  validate :dates_are_valid, on: :update
 
   def self.frameworks
     pluck(:framework)
   end
 
   def self.live_frameworks
-    where('live_at <= ?', Time.now.in_time_zone('London')).pluck(:framework)
+    where('live_at <= ? AND expires_at > ?', Time.now.in_time_zone('London'), Time.now.in_time_zone('London')).pluck(:framework)
   end
 
   def self.current_framework
     live_frameworks.last
   end
 
-  def self.current_live_framework?(framework)
-    current_framework == framework
+  def self.live_framework?(framework)
+    live_frameworks.include?(framework)
   end
 
   def self.recognised_framework?(framework)
@@ -27,7 +28,7 @@ class Framework < ApplicationRecord
   end
 
   def status
-    if self.class.send(service).current_live_framework?(framework)
+    if self.class.send(service).live_framework?(framework)
       :live
     else
       live_at <= Time.now.in_time_zone('London') ? :expired : :coming
@@ -36,11 +37,24 @@ class Framework < ApplicationRecord
 
   private
 
-  def live_at_date_present
-    errors.add(:live_at, :blank) if live_at_yyyy.blank? || live_at_mm.blank? || live_at_dd.blank?
+  def dates_are_valid
+    date_present(:live_at)
+    date_present(:expires_at)
+    date_real(:live_at)
+    date_real(:expires_at)
+
+    validate_expires_at_after_live_at if errors.none?
   end
 
-  def live_at_date_real
-    errors.add(:live_at, :not_a_date) unless Date.valid_date?(live_at_yyyy.to_i, live_at_mm.to_i, live_at_dd.to_i)
+  def date_present(attribute)
+    errors.add(attribute, :blank) if send("#{attribute}_yyyy").blank? || send("#{attribute}_mm").blank? || send("#{attribute}_dd").blank?
+  end
+
+  def date_real(attribute)
+    errors.add(attribute, :not_a_date) unless Date.valid_date?(send("#{attribute}_yyyy").to_i, send("#{attribute}_mm").to_i, send("#{attribute}_dd").to_i)
+  end
+
+  def validate_expires_at_after_live_at
+    errors.add(:expires_at, :not_after_live_at_date) unless expires_at > live_at
   end
 end

--- a/app/views/legal_services/home/unrecognised_framework.html.erb
+++ b/app/views/legal_services/home/unrecognised_framework.html.erb
@@ -1,0 +1,17 @@
+<%= content_for :page_title, t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
+    <p><%= t('.make_sure_listed', framework: @unrecognised_framework) %></p>
+    <p><%= t('.the_recognised_are') %></p>
+    <ul class="govuk-list govuk-list--bullet">
+      <% Framework.legal_services.live_frameworks.each do |framework| %>
+        <li>
+          <%= link_to framework, legal_services_index_path(framework: framework), class: 'govuk-link' %>
+        </li>
+      <% end %>
+    </ul>
+    <%= render partial: 'errors/contact_ccs' %>
+  </div>
+</div>

--- a/app/views/management_consultancy/home/unrecognised_framework.html.erb
+++ b/app/views/management_consultancy/home/unrecognised_framework.html.erb
@@ -1,0 +1,17 @@
+<%= content_for :page_title, t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
+    <p><%= t('.make_sure_listed', framework: @unrecognised_framework) %></p>
+    <p><%= t('.the_recognised_are') %></p>
+    <ul class="govuk-list govuk-list--bullet">
+      <% Framework.management_consultancy.live_frameworks.each do |framework| %>
+        <li>
+          <%= link_to framework, management_consultancy_index_path(framework: framework), class: 'govuk-link' %>
+        </li>
+      <% end %>
+    </ul>
+    <%= render partial: 'errors/contact_ccs' %>
+  </div>
+</div>

--- a/app/views/shared/admin/frameworks/_edit.html.erb
+++ b/app/views/shared/admin/frameworks/_edit.html.erb
@@ -5,17 +5,30 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-m">
+        Update the framework dates
+      </h1>
+
       <div class="govuk-!-margin-top-5">
-        <div class="govuk-form-group <%= 'govuk-form-group--error' if @framework.errors[:live_at].any?%>">
-          <h1 class="govuk-label-wrapper">
-            <%= f.label :live_at, t('.update_live_at_date', framework: @framework.framework), class: "govuk-label--m"%>
-          </h1>
-          <p class="govuk-caption-m">
-            <%= t('.buyer_section_visible', current_date: Time.now.in_time_zone('London').strftime('%e/%-m/%Y'))%>
-          </p>
+        <%= govuk_form_group_with_optional_error(@framework, :live_at) do %>
+          <%= f.label :live_at, t('.live_at_date', framework: @framework.framework), class: "govuk-label"%>
+          <div id="live-at-hint" class="govuk-hint">
+            <%= t('.live_at_hint', current_date: Time.now.in_time_zone('London').strftime('%e/%-m/%Y'))%>
+          </div>
           <%= display_errors(f.object, :live_at)%>
-          <%= f.gov_uk_date_field :live_at, legend_options: { page_heading: false, visually_hidden: true } %>
-        </div>
+          <%= f.gov_uk_date_field :live_at, legend_options: { page_heading: false, visually_hidden: true }, aria: { describedby: 'ive-at-hint' } %>
+        <% end %>
+      </div>
+
+      <div class="govuk-!-margin-top-5">
+        <%= govuk_form_group_with_optional_error(@framework, :expires_at) do %>
+          <%= f.label :expires_at, t('.expires_at_date', framework: @framework.framework), class: "govuk-label"%>
+          <div id="expires-at-hint" class="govuk-hint">
+            <%= t('.expires_at_hint', current_date: Time.now.in_time_zone('London').strftime('%e/%-m/%Y'))%>
+          </div>
+          <%= display_errors(f.object, :expires_at)%>
+          <%= f.gov_uk_date_field :expires_at, legend_options: { page_heading: false, visually_hidden: true }, aria: { describedby: 'expires-at-hint' } %>
+        <% end %>
       </div>
 
       <%= f.submit t('.save_and_return'), class: 'govuk-button', aria: { label: t('.save_and_return')} %>

--- a/app/views/shared/admin/frameworks/_index.html.erb
+++ b/app/views/shared/admin/frameworks/_index.html.erb
@@ -27,6 +27,7 @@
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header"><%= t('.framework') %></th>
           <th scope="col" class="govuk-table__header"><%= t('.live_at') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.expires_at') %></th>
           <th scope="col" class="govuk-table__header"><%= t('.status') %></th>
           <td class="govuk-table__header"></td>
         </tr>
@@ -36,6 +37,7 @@
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"><%= framework.framework %></th>
             <td class="govuk-table__cell"><%= format_date(framework.live_at) %></td>
+            <td class="govuk-table__cell"><%= format_date(framework.expires_at) %></td>
             <td class="govuk-table__cell">
               <% case framework.status %>
               <% when :live %>

--- a/app/views/supply_teachers/home/unrecognised_framework.html.erb
+++ b/app/views/supply_teachers/home/unrecognised_framework.html.erb
@@ -1,0 +1,17 @@
+<%= content_for :page_title, t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
+    <p><%= t('.make_sure_listed', framework: @unrecognised_framework) %></p>
+    <p><%= t('.the_recognised_are') %></p>
+    <ul class="govuk-list govuk-list--bullet">
+      <% Framework.supply_teachers.live_frameworks.each do |framework| %>
+        <li>
+          <%= link_to framework, supply_teachers_index_path(framework: framework), class: 'govuk-link' %>
+        </li>
+      <% end %>
+    </ul>
+    <%= render partial: 'errors/contact_ccs' %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,10 @@ en:
       models:
         framework:
           attributes:
+            expires_at:
+              blank: Enter a valid 'expires at' date
+              not_a_date: Enter a valid 'expires at' date
+              not_after_live_at_date: The 'expires at' date must be after the 'live at' date
             live_at:
               blank: Enter a valid 'live at' date
               not_a_date: Enter a valid 'live at' date

--- a/config/locales/views/legal_services.en.yml
+++ b/config/locales/views/legal_services.en.yml
@@ -83,6 +83,12 @@ en:
           make_sure_listed: The framework in the web address is '%{framework}'. Make sure the web address contains one of the listed frameworks.
           page_title: Unrecognised framework
           the_recognised_are: 'The Legal Services frameworks are:'
+    home:
+      unrecognised_framework:
+        heading: The web address contained an unrecognised framework
+        make_sure_listed: The framework in the web address is '%{framework}'. Make sure the web address contains one of the listed frameworks.
+        page_title: Unrecognised framework
+        the_recognised_are: 'The Legal Services frameworks are:'
     rm3788:
       admin:
         passwords:

--- a/config/locales/views/management_consultancy.en.yml
+++ b/config/locales/views/management_consultancy.en.yml
@@ -56,6 +56,12 @@ en:
           make_sure_listed: The framework in the web address is '%{framework}'. Make sure the web address contains one of the listed frameworks.
           page_title: Unrecognised framework
           the_recognised_are: 'The Management Consultancy frameworks are:'
+    home:
+      unrecognised_framework:
+        heading: The web address contained an unrecognised framework
+        make_sure_listed: The framework in the web address is '%{framework}'. Make sure the web address contains one of the listed frameworks.
+        page_title: Unrecognised framework
+        the_recognised_are: 'The Management Consultancy frameworks are:'
     rm6187:
       admin:
         passwords:

--- a/config/locales/views/shared.en.yml
+++ b/config/locales/views/shared.en.yml
@@ -4,15 +4,18 @@ en:
     admin:
       frameworks:
         edit:
-          buyer_section_visible: The buyer section for this framework will be visible if the 'live at' date is today (%{current_date}) or earlier.
+          expires_at_date: Framework 'expires at' date for %{framework}
+          expires_at_hint: The buyer section for this framework will not be visible if the date today (%{current_date}) is on or after the 'expires at' date.
+          live_at_date: Framework 'live at' date for %{framework}
+          live_at_hint: The buyer section for this framework will be visible if the 'live at' date is today (%{current_date}) or earlier.
           page_title: Framework 'live at' date
           return_to_frameworks: Return to %{service_name} frameworks
           save_and_return: Save and return
-          update_live_at_date: Update framework 'live at' date for %{framework}
         index:
           change: Change
           coming: coming
           expired: Expired
+          expires_at: Expires at
           framework: Framework
           if_the_framework: If the framework 'live at' date is before the current date (%{current_date}), the buyer section for this framework will be accessible to our customers.
           live: live

--- a/config/locales/views/supply_teachers.en.yml
+++ b/config/locales/views/supply_teachers.en.yml
@@ -177,6 +177,12 @@ en:
           make_sure_listed: The framework in the web address is '%{framework}'. Make sure the web address contains one of the listed frameworks.
           page_title: Unrecognised framework
           the_recognised_are: 'The Supply Teachers frameworks are:'
+    home:
+      unrecognised_framework:
+        heading: The web address contained an unrecognised framework
+        make_sure_listed: The framework in the web address is '%{framework}'. Make sure the web address contains one of the listed frameworks.
+        page_title: Unrecognised framework
+        the_recognised_are: 'The Supply Teachers frameworks are:'
     rm3826:
       admin:
         passwords:

--- a/db/migrate/20220616110030_add_end_date_to_frameworks.rb
+++ b/db/migrate/20220616110030_add_end_date_to_frameworks.rb
@@ -1,0 +1,5 @@
+class AddEndDateToFrameworks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :frameworks, :expires_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_09_084611) do
+ActiveRecord::Schema.define(version: 2022_06_16_110030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2022_05_09_084611) do
     t.date "live_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.date "expires_at"
   end
 
   create_table "legal_services_rm3788_admin_uploads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/features/services/legal_services/unrecognised_framework.feature
+++ b/features/services/legal_services/unrecognised_framework.feature
@@ -3,12 +3,18 @@ Feature: Legal Services - Start pages - With an unrecognised framework
 
   Scenario: Go to unrecognised famework in the buyer section - logged in
     When I go to the 'legal services' start page for 'RM007'
+    Then I am on the 'The web address contained an unrecognised framework' page
+    And the unrecognised framework is 'RM007'
+    And I click on 'RM3788'
     Then I am on the 'Find legal services for the wider public sector' page
     And the framework is 'RM3788'
 
   Scenario: Go to unrecognised famework in the buyer section - logged out
     Given I sign in and navigate to the start page for the 'RM3788' framework in 'legal services'
     And I go to the 'legal services' start page for 'RM1012'
+    Then I am on the 'The web address contained an unrecognised framework' page
+    And the unrecognised framework is 'RM1012'
+    And I click on 'RM3788'
     Then I am on the 'Find legal services for the wider public sector' page
     And the framework is 'RM3788'
 

--- a/features/services/management_consultancy/unrecognised_framework.feature
+++ b/features/services/management_consultancy/unrecognised_framework.feature
@@ -3,12 +3,18 @@ Feature: Management Consultancy - Start pages - With an unrecognised framework
 
   Scenario: Go to unrecognised famework in the buyer section - logged in
     When I go to the 'management consultancy' start page for 'RM007'
+    Then I am on the 'The web address contained an unrecognised framework' page
+    And the unrecognised framework is 'RM007'
+    And I click on 'RM6187'
     Then I am on the 'Find management consultants' page
     And the framework is 'RM6187'
 
   Scenario: Go to unrecognised famework in the buyer section - logged out
     Given I sign in and navigate to the start page for the 'RM6187' framework in 'management consultancy'
     And I go to the 'management consultancy' start page for 'RM9812'
+    Then I am on the 'The web address contained an unrecognised framework' page
+    And the unrecognised framework is 'RM9812'
+    And I click on 'RM6187'
     Then I am on the 'Find management consultants' page
     And the framework is 'RM6187'
 

--- a/features/services/supply_teachers/unrecognised_framework.feature
+++ b/features/services/supply_teachers/unrecognised_framework.feature
@@ -3,12 +3,18 @@ Feature: Supply Teachers - Start pages - With an unrecognised framework
 
   Scenario: Go to unrecognised famework in the buyer section - logged in
     When I go to the 'supply teachers' start page for 'RM007'
+    Then I am on the 'The web address contained an unrecognised framework' page
+    And the unrecognised framework is 'RM007'
+    And I click on 'RM3826'
     Then I am on the 'Find supply teachers and agency workers' page
     And the framework is 'RM3826'
 
   Scenario: Go to unrecognised famework in the buyer section - logged out
     Given I sign in and navigate to the start page for the 'RM3826' framework in 'supply teachers'
     And I go to the 'supply teachers' start page for 'RM0172'
+    Then I am on the 'The web address contained an unrecognised framework' page
+    And the unrecognised framework is 'RM0172'
+    And I click on 'RM3826'
     Then I am on the 'Find supply teachers and agency workers' page
     And the framework is 'RM3826'
 

--- a/lib/tasks/frameworks.rake
+++ b/lib/tasks/frameworks.rake
@@ -8,6 +8,15 @@ module Frameworks
     end
   end
 
+  def self.rm6238_expires_at
+    if Rails.env.test?
+      Time.zone.now + 1.year
+    else
+      # This is not correct but it is far in the future and we can update it with another migration later on
+      Time.new(2026, 9, 1).in_time_zone('London')
+    end
+  end
+
   def self.rm6240_live_at
     if Rails.env.test?
       Time.zone.now - 1.day
@@ -17,13 +26,22 @@ module Frameworks
     end
   end
 
+  def self.rm6240_expires_at
+    if Rails.env.test?
+      Time.zone.now + 1.year
+    else
+      # This is not correct but it is far in the future and we can update it with another migration later on
+      Time.new(2026, 10, 1).in_time_zone('London')
+    end
+  end
+
   def self.add_frameworks
     ActiveRecord::Base.connection.truncate_tables(:frameworks)
-    Framework.create(service: 'supply_teachers', framework: 'RM3826', live_at: Time.new(2020, 6, 26).in_time_zone('London'))
-    Framework.create(service: 'supply_teachers', framework: 'RM6238', live_at: rm6238_live_at)
-    Framework.create(service: 'management_consultancy', framework: 'RM6187', live_at: Time.new(2021, 9, 4).in_time_zone('London'))
-    Framework.create(service: 'legal_services', framework: 'RM3788', live_at: Time.new(2020, 6, 26).in_time_zone('London'))
-    Framework.create(service: 'legal_services', framework: 'RM6240', live_at: rm6240_live_at)
+    Framework.create(service: 'supply_teachers', framework: 'RM3826', live_at: Time.new(2020, 6, 26).in_time_zone('London'), expires_at: Time.new(2025, 6, 26).in_time_zone('London'))
+    Framework.create(service: 'supply_teachers', framework: 'RM6238', live_at: rm6238_live_at, expires_at: rm6238_expires_at)
+    Framework.create(service: 'management_consultancy', framework: 'RM6187', live_at: Time.new(2021, 9, 4).in_time_zone('London'), expires_at: Time.new(2025, 9, 4).in_time_zone('London'))
+    Framework.create(service: 'legal_services', framework: 'RM3788', live_at: Time.new(2020, 6, 26).in_time_zone('London'), expires_at: Time.new(2025, 6, 26).in_time_zone('London'))
+    Framework.create(service: 'legal_services', framework: 'RM6240', live_at: rm6240_live_at, expires_at: rm6240_expires_at)
   end
 end
 

--- a/spec/controllers/legal_services/home_controller_spec.rb
+++ b/spec/controllers/legal_services/home_controller_spec.rb
@@ -24,10 +24,11 @@ RSpec.describe LegalServices::HomeController, type: :controller do
   describe 'GET index' do
     context 'when RM6240 is live' do
       context 'and the framework is not RM3788 or RM6240' do
-        it 'redirects to the framework path' do
+        it 'renders the unrecognised framework page with the right http status' do
           get :index, params: { framework: 'RM3826' }
 
-          expect(response).to redirect_to legal_services_path
+          expect(response).to render_template('legal_services/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
 
@@ -42,11 +43,24 @@ RSpec.describe LegalServices::HomeController, type: :controller do
       end
 
       context 'and the framework is RM3788' do
-        it 'redirects to the framework path' do
-          get :index, params: { framework: 'RM3788' }
-
-          expect(response).to redirect_to legal_services_path
+        it 'raises the MissingExactTemplate error' do
+          expect do
+            get :index, params: { framework: 'RM3788' }
+          end.to raise_error(ActionController::MissingExactTemplate)
         end
+
+        # rubocop:disable RSpec/NestedGroups
+        context 'and RM3788 framework expires today' do
+          include_context 'and RM3788 has expired'
+
+          it 'renders the unrecognised framework page with the right http status' do
+            get :index, params: { framework: 'RM3788' }
+
+            expect(response).to render_template('legal_services/home/unrecognised_framework')
+            expect(response).to have_http_status(:bad_request)
+          end
+        end
+        # rubocop:enable RSpec/NestedGroups
       end
     end
 
@@ -54,18 +68,20 @@ RSpec.describe LegalServices::HomeController, type: :controller do
       include_context 'and RM6240 is live in the future'
 
       context 'and the framework is not RM3788 or RM6240' do
-        it 'redirects to the framework path' do
+        it 'renders the unrecognised framework page with the right http status' do
           get :index, params: { framework: 'RM3826' }
 
-          expect(response).to redirect_to legal_services_path
+          expect(response).to render_template('legal_services/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
 
       context 'and the framework is RM6240' do
-        it 'redirects to the framework path' do
+        it 'renders the unrecognised framework page with the right http status' do
           get :index, params: { framework: 'RM6240' }
 
-          expect(response).to redirect_to legal_services_path
+          expect(response).to render_template('legal_services/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
 

--- a/spec/controllers/legal_services/journey_controller_rm3788_spec.rb
+++ b/spec/controllers/legal_services/journey_controller_rm3788_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe LegalServices::JourneyController, type: :controller do
     context 'when the framework is not the current framework' do
       let(:framework) { 'RM6240' }
 
-      it 'redirects to the framework path' do
-        expect(response).to redirect_to legal_services_path
+      it 'renders the unrecognised framework page with the right http status' do
+        expect(response).to render_template('legal_services/home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/controllers/legal_services/rm3788/suppliers_controller_spec.rb
+++ b/spec/controllers/legal_services/rm3788/suppliers_controller_spec.rb
@@ -65,8 +65,9 @@ RSpec.describe LegalServices::RM3788::SuppliersController, type: :controller do
       context 'when the framework is not the current framework' do
         let(:framework) { 'RM6240' }
 
-        it 'redirects to the framework path' do
-          expect(response).to redirect_to legal_services_path
+        it 'renders the unrecognised framework page with the right http status' do
+          expect(response).to render_template('legal_services/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end
@@ -96,8 +97,9 @@ RSpec.describe LegalServices::RM3788::SuppliersController, type: :controller do
     context 'when the framework is not the current framework' do
       let(:framework) { 'RM6240' }
 
-      it 'redirects to the framework path' do
-        expect(response).to redirect_to legal_services_path
+      it 'renders the unrecognised framework page with the right http status' do
+        expect(response).to render_template('legal_services/home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -117,8 +119,9 @@ RSpec.describe LegalServices::RM3788::SuppliersController, type: :controller do
       context 'when the framework is not the current framework' do
         let(:framework) { 'RM6240' }
 
-        it 'redirects to the framework path' do
-          expect(response).to redirect_to legal_services_path
+        it 'renders the unrecognised framework page with the right http status' do
+          expect(response).to render_template('legal_services/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end

--- a/spec/controllers/management_consultancy/home_controller_spec.rb
+++ b/spec/controllers/management_consultancy/home_controller_spec.rb
@@ -12,10 +12,11 @@ RSpec.describe ManagementConsultancy::HomeController, type: :controller do
 
   describe 'GET index' do
     context 'when the framework is not the current framework' do
-      it 'redirects to the framework path' do
+      it 'renders the unrecognised framework page with the right http status' do
         get :index, params: { framework: 'RM6232' }
 
-        expect(response).to redirect_to management_consultancy_path
+        expect(response).to render_template('management_consultancy/home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
 

--- a/spec/controllers/management_consultancy/rm6187/suppliers_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/suppliers_controller_spec.rb
@@ -50,8 +50,9 @@ RSpec.describe ManagementConsultancy::RM6187::SuppliersController, type: :contro
       context 'when the framework is not the current framework' do
         let(:framework) { 'RM6232' }
 
-        it 'redirects to the framework path' do
-          expect(response).to redirect_to management_consultancy_path
+        it 'renders the unrecognised framework page with the right http status' do
+          expect(response).to render_template('management_consultancy/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end
@@ -94,8 +95,9 @@ RSpec.describe ManagementConsultancy::RM6187::SuppliersController, type: :contro
       context 'when the framework is not the current framework' do
         let(:framework) { 'RM6232' }
 
-        it 'redirects to the framework path' do
-          expect(response).to redirect_to management_consultancy_path
+        it 'renders the unrecognised framework page with the right http status' do
+          expect(response).to render_template('management_consultancy/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end
@@ -121,8 +123,9 @@ RSpec.describe ManagementConsultancy::RM6187::SuppliersController, type: :contro
       context 'when the framework is not the current framework' do
         let(:framework) { 'RM6232' }
 
-        it 'redirects to the framework path' do
-          expect(response).to redirect_to management_consultancy_path
+        it 'renders the unrecognised framework page with the right http status' do
+          expect(response).to render_template('management_consultancy/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end
@@ -141,8 +144,9 @@ RSpec.describe ManagementConsultancy::RM6187::SuppliersController, type: :contro
       context 'when the framework is not the current framework' do
         let(:framework) { 'RM6232' }
 
-        it 'redirects to the framework path' do
-          expect(response).to redirect_to management_consultancy_path
+        it 'renders the unrecognised framework page with the right http status' do
+          expect(response).to render_template('management_consultancy/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end

--- a/spec/controllers/supply_teachers/home_controller_spec.rb
+++ b/spec/controllers/supply_teachers/home_controller_spec.rb
@@ -24,10 +24,11 @@ RSpec.describe SupplyTeachers::HomeController, type: :controller do
   describe 'GET index' do
     context 'when RM6238 is live' do
       context 'and the framework is not RM3826 or RM6238' do
-        it 'redirects to the framework path' do
+        it 'renders the unrecognised framework page with the right http status' do
           get :index, params: { framework: 'RM6187' }
 
-          expect(response).to redirect_to supply_teachers_path
+          expect(response).to render_template('supply_teachers/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
 
@@ -42,11 +43,24 @@ RSpec.describe SupplyTeachers::HomeController, type: :controller do
       end
 
       context 'and the framework is RM3826' do
-        it 'redirects to the framework path' do
-          get :index, params: { framework: 'RM3826' }
-
-          expect(response).to redirect_to supply_teachers_path
+        it 'raises the MissingExactTemplate error' do
+          expect do
+            get :index, params: { framework: 'RM3826' }
+          end.to raise_error(ActionController::MissingExactTemplate)
         end
+
+        # rubocop:disable RSpec/NestedGroups
+        context 'and RM3826 framework expires today' do
+          include_context 'and RM3826 has expired'
+
+          it 'renders the unrecognised framework page with the right http status' do
+            get :index, params: { framework: 'RM3826' }
+
+            expect(response).to render_template('supply_teachers/home/unrecognised_framework')
+            expect(response).to have_http_status(:bad_request)
+          end
+        end
+        # rubocop:enable RSpec/NestedGroups
       end
     end
 
@@ -54,18 +68,20 @@ RSpec.describe SupplyTeachers::HomeController, type: :controller do
       include_context 'and RM6238 is live in the future'
 
       context 'and the framework is not RM3826 or RM6238' do
-        it 'redirects to the framework path' do
+        it 'renders the unrecognised framework page with the right http status' do
           get :index, params: { framework: 'RM6187' }
 
-          expect(response).to redirect_to supply_teachers_path
+          expect(response).to render_template('supply_teachers/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
 
       context 'and the framework is RM6238' do
-        it 'redirects to the framework path' do
+        it 'renders the unrecognised framework page with the right http status' do
           get :index, params: { framework: 'RM6238' }
 
-          expect(response).to redirect_to supply_teachers_path
+          expect(response).to render_template('supply_teachers/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
 

--- a/spec/controllers/supply_teachers/journey_controller_rm3826_spec.rb
+++ b/spec/controllers/supply_teachers/journey_controller_rm3826_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe SupplyTeachers::JourneyController, type: :controller do
     context 'when the framework is not the current framework' do
       let(:framework) { 'RM6238' }
 
-      it 'redirects to the framework path' do
-        expect(response).to redirect_to supply_teachers_path
+      it 'renders the unrecognised framework page with the right http status' do
+        expect(response).to render_template('supply_teachers/home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/controllers/supply_teachers/rm3826/branches_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm3826/branches_controller_spec.rb
@@ -22,10 +22,11 @@ RSpec.describe SupplyTeachers::RM3826::BranchesController, type: :controller do
 
       let(:framework) { 'RM6238' }
 
-      it 'redirects to the framework path' do
+      it 'renders the unrecognised framework page with the right http status' do
         get :index
 
-        expect(response).to redirect_to supply_teachers_path
+        expect(response).to render_template('supply_teachers/home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
 

--- a/spec/controllers/supply_teachers/rm3826/gateway_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm3826/gateway_controller_spec.rb
@@ -17,14 +17,16 @@ RSpec.describe SupplyTeachers::RM3826::GatewayController, type: :controller do
       context 'when the framework is not the current framework' do
         let(:framework) { 'RM6238' }
 
-        it 'redirects to the framework path' do
-          expect(response).to redirect_to supply_teachers_path
+        it 'renders the unrecognised framework page with the right http status' do
+          expect(response).to render_template('supply_teachers/home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end
 
     context 'when signed in' do
       login_st_buyer
+
       it 'redirects to the framework start page' do
         get :index
         expect(response).to redirect_to(supply_teachers_path)

--- a/spec/controllers/supply_teachers/rm3826/suppliers_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm3826/suppliers_controller_spec.rb
@@ -72,8 +72,9 @@ RSpec.describe SupplyTeachers::RM3826::SuppliersController, type: :controller do
     context 'when the framework is not the current framework' do
       let(:framework) { 'RM6238' }
 
-      it 'redirects to the framework path' do
-        expect(response).to redirect_to supply_teachers_path
+      it 'renders the unrecognised framework page with the right http status' do
+        expect(response).to render_template('supply_teachers/home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/factories/frameworks.rb
+++ b/spec/factories/frameworks.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     service { ('a'..'z').to_a.sample(8).join }
     framework { "FK#{Array.new(4) { rand(10) }.join}" }
     live_at { Time.zone.now + 1.year }
+    expires_at { Time.zone.now + 2.years }
   end
 end

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
+# rubocop:disable RSpec/NestedGroups
 RSpec.describe Framework, type: :model do
   describe '.frameworks' do
     context 'when no scope is provided' do
@@ -40,6 +41,20 @@ RSpec.describe Framework, type: :model do
           expect(described_class.supply_teachers.live_frameworks).to eq %w[RM3826]
         end
       end
+
+      context 'and RM3826 framework expires today' do
+        include_context 'and RM3826 has expired'
+
+        it 'returns RM6187, RM3788 and RM6240' do
+          expect(described_class.live_frameworks).to eq %w[RM6187 RM3788 RM6240]
+        end
+
+        context 'and the supply_teachers scope is provided' do
+          it 'returns an empty array' do
+            expect(described_class.supply_teachers.live_frameworks).to eq %w[]
+          end
+        end
+      end
     end
 
     context 'when RM6240 goes live tomorrow' do
@@ -52,6 +67,20 @@ RSpec.describe Framework, type: :model do
       context 'and the legal_services scope is provided' do
         it 'returns RM3788' do
           expect(described_class.legal_services.live_frameworks).to eq %w[RM3788]
+        end
+      end
+
+      context 'and RM3788 framework expires today' do
+        include_context 'and RM3788 has expired'
+
+        it 'returns RM3826, RM6238 and RM6187' do
+          expect(described_class.live_frameworks).to eq %w[RM3826 RM6238 RM6187]
+        end
+
+        context 'and the legal_services scope is provided' do
+          it 'returns an empty array' do
+            expect(described_class.legal_services.live_frameworks).to eq %w[]
+          end
         end
       end
     end
@@ -68,6 +97,20 @@ RSpec.describe Framework, type: :model do
           expect(described_class.supply_teachers.live_frameworks).to eq %w[RM3826 RM6238]
         end
       end
+
+      context 'and RM3826 framework expires today' do
+        include_context 'and RM3826 has expired'
+
+        it 'returns RM6238, RM6187, RM6240 and RM3788' do
+          expect(described_class.live_frameworks).to eq %w[RM6187 RM3788 RM6240 RM6238]
+        end
+
+        context 'and the supply_teachers scope is provided' do
+          it 'returns RM6238' do
+            expect(described_class.supply_teachers.live_frameworks).to eq %w[RM6238]
+          end
+        end
+      end
     end
 
     context 'when RM6240 is live today' do
@@ -82,6 +125,20 @@ RSpec.describe Framework, type: :model do
           expect(described_class.legal_services.live_frameworks).to eq %w[RM3788 RM6240]
         end
       end
+
+      context 'and RM3788 framework expires today' do
+        include_context 'and RM3788 has expired'
+
+        it 'returns RM3826, RM6238, RM6187 and RM6240' do
+          expect(described_class.live_frameworks).to eq %w[RM3826 RM6238 RM6187 RM6240]
+        end
+
+        context 'and the legal_services scope is provided' do
+          it 'returns RM6240' do
+            expect(described_class.legal_services.live_frameworks).to eq %w[RM6240]
+          end
+        end
+      end
     end
 
     context 'when RM6238 went live yesterday' do
@@ -92,6 +149,20 @@ RSpec.describe Framework, type: :model do
       context 'and the supply_teachers scope is provided' do
         it 'returns RM3826 and RM6238' do
           expect(described_class.supply_teachers.live_frameworks).to eq %w[RM3826 RM6238]
+        end
+      end
+
+      context 'and RM3826 framework expires today' do
+        include_context 'and RM3826 has expired'
+
+        it 'returns RM6238, RM6187, RM3788 and RM6240' do
+          expect(described_class.live_frameworks).to eq %w[RM6238 RM6187 RM3788 RM6240]
+        end
+
+        context 'and the supply_teachers scope is provided' do
+          it 'returns RM6238' do
+            expect(described_class.supply_teachers.live_frameworks).to eq %w[RM6238]
+          end
         end
       end
     end
@@ -106,6 +177,20 @@ RSpec.describe Framework, type: :model do
           expect(described_class.legal_services.live_frameworks).to eq %w[RM3788 RM6240]
         end
       end
+
+      context 'and RM3788 framework expires today' do
+        include_context 'and RM3788 has expired'
+
+        it 'returns RM3826, RM6238, RM6187 and RM6240' do
+          expect(described_class.live_frameworks).to eq %w[RM3826 RM6238 RM6187 RM6240]
+        end
+
+        context 'and the legal_services scope is provided' do
+          it 'returns RM6240' do
+            expect(described_class.legal_services.live_frameworks).to eq %w[RM6240]
+          end
+        end
+      end
     end
   end
 
@@ -117,6 +202,14 @@ RSpec.describe Framework, type: :model do
         it 'returns RM3826' do
           expect(described_class.supply_teachers.current_framework).to eq 'RM3826'
         end
+
+        context 'and RM3826 framework expires today' do
+          include_context 'and RM3826 has expired'
+
+          it 'returns nil' do
+            expect(described_class.supply_teachers.current_framework).to be nil
+          end
+        end
       end
 
       context 'when RM6238 is live today' do
@@ -125,11 +218,27 @@ RSpec.describe Framework, type: :model do
         it 'returns RM6238' do
           expect(described_class.supply_teachers.current_framework).to eq 'RM6238'
         end
+
+        context 'and RM3826 framework expires today' do
+          include_context 'and RM3826 has expired'
+
+          it 'returns RM6238' do
+            expect(described_class.supply_teachers.current_framework).to eq 'RM6238'
+          end
+        end
       end
 
       context 'when RM6238 went live yesterday' do
         it 'returns RM6238' do
           expect(described_class.supply_teachers.current_framework).to eq 'RM6238'
+        end
+
+        context 'and RM3826 framework expires today' do
+          include_context 'and RM3826 has expired'
+
+          it 'returns RM6238' do
+            expect(described_class.supply_teachers.current_framework).to eq 'RM6238'
+          end
         end
       end
     end
@@ -147,6 +256,14 @@ RSpec.describe Framework, type: :model do
         it 'returns RM3788' do
           expect(described_class.legal_services.current_framework).to eq 'RM3788'
         end
+
+        context 'and RM3788 framework expires today' do
+          include_context 'and RM3788 has expired'
+
+          it 'returns nil' do
+            expect(described_class.legal_services.current_framework).to be nil
+          end
+        end
       end
 
       context 'when RM6240 is live today' do
@@ -155,20 +272,35 @@ RSpec.describe Framework, type: :model do
         it 'returns RM6240' do
           expect(described_class.legal_services.current_framework).to eq 'RM6240'
         end
+
+        context 'and RM3788 framework expires today' do
+          include_context 'and RM3788 has expired'
+
+          it 'returns RM6240' do
+            expect(described_class.legal_services.current_framework).to eq 'RM6240'
+          end
+        end
       end
 
       context 'when RM6240 went live yesterday' do
         it 'returns RM6240' do
           expect(described_class.legal_services.current_framework).to eq 'RM6240'
         end
+
+        context 'and RM3788 framework expires today' do
+          include_context 'and RM3788 has expired'
+
+          it 'returns RM6240' do
+            expect(described_class.legal_services.current_framework).to eq 'RM6240'
+          end
+        end
       end
     end
   end
 
-  # rubocop:disable RSpec/NestedGroups
-  describe '.current_live_framework?' do
+  describe '.live_framework?' do
     context 'when the supply_teachers scope is provided' do
-      let(:result) { described_class.supply_teachers.current_live_framework?(framework) }
+      let(:result) { described_class.supply_teachers.live_framework?(framework) }
 
       context 'when the framework passed is RM3826' do
         let(:framework) { 'RM3826' }
@@ -179,19 +311,43 @@ RSpec.describe Framework, type: :model do
           it 'returns true' do
             expect(result).to be true
           end
+
+          context 'and RM3826 framework expires today' do
+            include_context 'and RM3826 has expired'
+
+            it 'returns false' do
+              expect(result).to be false
+            end
+          end
         end
 
         context 'when RM6238 is live today' do
           include_context 'and RM6238 is live today'
 
-          it 'returns false' do
-            expect(result).to be false
+          it 'returns true' do
+            expect(result).to be true
+          end
+
+          context 'and RM3826 framework expires today' do
+            include_context 'and RM3826 has expired'
+
+            it 'returns false' do
+              expect(result).to be false
+            end
           end
         end
 
         context 'and RM6238 went live yesterday' do
-          it 'returns false' do
-            expect(result).to be false
+          it 'returns true' do
+            expect(result).to be true
+          end
+
+          context 'and RM3826 framework expires today' do
+            include_context 'and RM3826 has expired'
+
+            it 'returns false' do
+              expect(result).to be false
+            end
           end
         end
       end
@@ -205,6 +361,14 @@ RSpec.describe Framework, type: :model do
           it 'returns false' do
             expect(result).to be false
           end
+
+          context 'and RM3826 framework expires today' do
+            include_context 'and RM3826 has expired'
+
+            it 'returns false' do
+              expect(result).to be false
+            end
+          end
         end
 
         context 'when RM6238 is live today' do
@@ -213,11 +377,27 @@ RSpec.describe Framework, type: :model do
           it 'returns true' do
             expect(result).to be true
           end
+
+          context 'and RM3826 framework expires today' do
+            include_context 'and RM3826 has expired'
+
+            it 'returns true' do
+              expect(result).to be true
+            end
+          end
         end
 
         context 'and RM6238 went live yesterday' do
           it 'returns true' do
             expect(result).to be true
+          end
+
+          context 'and RM3826 framework expires today' do
+            include_context 'and RM3826 has expired'
+
+            it 'returns true' do
+              expect(result).to be true
+            end
           end
         end
       end
@@ -234,19 +414,19 @@ RSpec.describe Framework, type: :model do
     context 'when the management_consultancy scope is provided' do
       context 'when the framework is RM6187' do
         it 'returns true' do
-          expect(described_class.management_consultancy.current_live_framework?('RM6187')).to be true
+          expect(described_class.management_consultancy.live_framework?('RM6187')).to be true
         end
       end
 
       context 'when the framework is not RM6187' do
         it 'returns false' do
-          expect(described_class.management_consultancy.current_live_framework?('RM3788')).to be false
+          expect(described_class.management_consultancy.live_framework?('RM3788')).to be false
         end
       end
     end
 
     context 'when the legal_services scope is provided' do
-      let(:result) { described_class.legal_services.current_live_framework?(framework) }
+      let(:result) { described_class.legal_services.live_framework?(framework) }
 
       context 'when the framework passed is RM3788' do
         let(:framework) { 'RM3788' }
@@ -257,19 +437,43 @@ RSpec.describe Framework, type: :model do
           it 'returns true' do
             expect(result).to be true
           end
+
+          context 'and RM3788 framework expires today' do
+            include_context 'and RM3788 has expired'
+
+            it 'returns false' do
+              expect(result).to be false
+            end
+          end
         end
 
         context 'when RM6240 is live today' do
           include_context 'and RM6240 is live today'
 
-          it 'returns false' do
-            expect(result).to be false
+          it 'returns true' do
+            expect(result).to be true
+          end
+
+          context 'and RM3788 framework expires today' do
+            include_context 'and RM3788 has expired'
+
+            it 'returns false' do
+              expect(result).to be false
+            end
           end
         end
 
         context 'and RM6240 went live yesterday' do
-          it 'returns false' do
-            expect(result).to be false
+          it 'returns true' do
+            expect(result).to be true
+          end
+
+          context 'and RM3788 framework expires today' do
+            include_context 'and RM3788 has expired'
+
+            it 'returns false' do
+              expect(result).to be false
+            end
           end
         end
       end
@@ -283,6 +487,14 @@ RSpec.describe Framework, type: :model do
           it 'returns false' do
             expect(result).to be false
           end
+
+          context 'and RM3788 framework expires today' do
+            include_context 'and RM3788 has expired'
+
+            it 'returns false' do
+              expect(result).to be false
+            end
+          end
         end
 
         context 'when RM6240 is live today' do
@@ -291,11 +503,27 @@ RSpec.describe Framework, type: :model do
           it 'returns true' do
             expect(result).to be true
           end
+
+          context 'and RM3788 framework expires today' do
+            include_context 'and RM3788 has expired'
+
+            it 'returns true' do
+              expect(result).to be true
+            end
+          end
         end
 
         context 'and RM6240 went live yesterday' do
           it 'returns true' do
             expect(result).to be true
+          end
+
+          context 'and RM3788 framework expires today' do
+            include_context 'and RM3788 has expired'
+
+            it 'returns true' do
+              expect(result).to be true
+            end
           end
         end
       end
@@ -324,6 +552,14 @@ RSpec.describe Framework, type: :model do
             it 'returns live' do
               expect(result).to eq :live
             end
+
+            context 'and RM3826 framework expires today' do
+              include_context 'and RM3826 has expired'
+
+              it 'returns expired' do
+                expect(result).to eq :expired
+              end
+            end
           end
 
           context 'and the frameworks is RM6238' do
@@ -331,6 +567,14 @@ RSpec.describe Framework, type: :model do
 
             it 'returns coming' do
               expect(result).to eq :coming
+            end
+
+            context 'and RM3826 framework expires today' do
+              include_context 'and RM3826 has expired'
+
+              it 'returns coming' do
+                expect(result).to eq :coming
+              end
             end
           end
         end
@@ -341,8 +585,16 @@ RSpec.describe Framework, type: :model do
           context 'and the frameworks is RM3826' do
             let(:framework) { 'RM3826' }
 
-            it 'returns expired' do
-              expect(result).to eq :expired
+            it 'returns live' do
+              expect(result).to eq :live
+            end
+
+            context 'and RM3826 framework expires today' do
+              include_context 'and RM3826 has expired'
+
+              it 'returns expired' do
+                expect(result).to eq :expired
+              end
             end
           end
 
@@ -351,6 +603,14 @@ RSpec.describe Framework, type: :model do
 
             it 'returns live' do
               expect(result).to eq :live
+            end
+
+            context 'and RM3826 framework expires today' do
+              include_context 'and RM3826 has expired'
+
+              it 'returns live' do
+                expect(result).to eq :live
+              end
             end
           end
         end
@@ -359,8 +619,16 @@ RSpec.describe Framework, type: :model do
           context 'and the frameworks is RM3826' do
             let(:framework) { 'RM3826' }
 
-            it 'returns expired' do
-              expect(result).to eq :expired
+            it 'returns live' do
+              expect(result).to eq :live
+            end
+
+            context 'and RM3826 framework expires today' do
+              include_context 'and RM3826 has expired'
+
+              it 'returns expired' do
+                expect(result).to eq :expired
+              end
             end
           end
 
@@ -369,6 +637,14 @@ RSpec.describe Framework, type: :model do
 
             it 'returns live' do
               expect(result).to eq :live
+            end
+
+            context 'and RM3826 framework expires today' do
+              include_context 'and RM3826 has expired'
+
+              it 'returns live' do
+                expect(result).to eq :live
+              end
             end
           end
         end
@@ -394,6 +670,14 @@ RSpec.describe Framework, type: :model do
             it 'returns live' do
               expect(result).to eq :live
             end
+
+            context 'and RM3788 framework expires today' do
+              include_context 'and RM3788 has expired'
+
+              it 'returns expired' do
+                expect(result).to eq :expired
+              end
+            end
           end
 
           context 'and the frameworks is RM6240' do
@@ -401,6 +685,14 @@ RSpec.describe Framework, type: :model do
 
             it 'returns coming' do
               expect(result).to eq :coming
+            end
+
+            context 'and RM3788 framework expires today' do
+              include_context 'and RM3788 has expired'
+
+              it 'returns expired' do
+                expect(result).to eq :coming
+              end
             end
           end
         end
@@ -411,8 +703,16 @@ RSpec.describe Framework, type: :model do
           context 'and the frameworks is RM3788' do
             let(:framework) { 'RM3788' }
 
-            it 'returns expired' do
-              expect(result).to eq :expired
+            it 'returns live' do
+              expect(result).to eq :live
+            end
+
+            context 'and RM3788 framework expires today' do
+              include_context 'and RM3788 has expired'
+
+              it 'returns expired' do
+                expect(result).to eq :expired
+              end
             end
           end
 
@@ -421,6 +721,14 @@ RSpec.describe Framework, type: :model do
 
             it 'returns live' do
               expect(result).to eq :live
+            end
+
+            context 'and RM3788 framework expires today' do
+              include_context 'and RM3788 has expired'
+
+              it 'returns live' do
+                expect(result).to eq :live
+              end
             end
           end
         end
@@ -429,8 +737,16 @@ RSpec.describe Framework, type: :model do
           context 'and the frameworks is RM3788' do
             let(:framework) { 'RM3788' }
 
-            it 'returns expired' do
-              expect(result).to eq :expired
+            it 'returns live' do
+              expect(result).to eq :live
+            end
+
+            context 'and RM3788 framework expires today' do
+              include_context 'and RM3788 has expired'
+
+              it 'returns expired' do
+                expect(result).to eq :expired
+              end
             end
           end
 
@@ -440,12 +756,19 @@ RSpec.describe Framework, type: :model do
             it 'returns live' do
               expect(result).to eq :live
             end
+
+            context 'and RM3788 framework expires today' do
+              include_context 'and RM3788 has expired'
+
+              it 'returns live' do
+                expect(result).to eq :live
+              end
+            end
           end
         end
       end
     end
   end
-  # rubocop:enable RSpec/NestedGroups
 
   describe 'validating the live at date' do
     let(:framework) { create(:legacy_framework) }
@@ -506,4 +829,96 @@ RSpec.describe Framework, type: :model do
       end
     end
   end
+
+  describe 'validating the expires at date' do
+    let(:framework) { create(:legacy_framework) }
+    let(:expires_at) { Time.zone.now + 2.years }
+    let(:expires_at_yyyy) { expires_at.year.to_s }
+    let(:expires_at_mm) { expires_at.month.to_s }
+    let(:expires_at_dd) { expires_at.day.to_s }
+
+    before do
+      framework.expires_at_yyyy = expires_at_yyyy
+      framework.expires_at_mm = expires_at_mm
+      framework.expires_at_dd = expires_at_dd
+    end
+
+    context 'when considering expires_at_yyyy and it is nil' do
+      let(:expires_at_yyyy) { nil }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:expires_at].first).to eq 'Enter a valid \'expires at\' date'
+      end
+    end
+
+    context 'when considering expires_at_mm and it is blank' do
+      let(:expires_at_mm) { '' }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:expires_at].first).to eq 'Enter a valid \'expires at\' date'
+      end
+    end
+
+    context 'when considering expires_at_dd and it is empty' do
+      let(:expires_at_dd) { '    ' }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:expires_at].first).to eq 'Enter a valid \'expires at\' date'
+      end
+    end
+
+    context 'when considering the full expires_at' do
+      context 'and it is not a real date' do
+        let(:expires_at_yyyy) { expires_at.year.to_s }
+        let(:expires_at_mm) { '2' }
+        let(:expires_at_dd) { '30' }
+
+        it 'is not valid and has the correct error message' do
+          expect(framework.valid?(:update)).to eq false
+          expect(framework.errors[:expires_at].first).to eq 'Enter a valid \'expires at\' date'
+        end
+      end
+
+      context 'and it is a real date' do
+        it 'is valid' do
+          expect(framework.valid?(:update)).to eq true
+        end
+      end
+    end
+  end
+
+  describe 'validating the expires at date is after the live at date' do
+    let(:framework) { create(:legacy_framework, live_at: today, expires_at: expires_at) }
+    let(:today) { Time.zone.today }
+
+    context 'when the expires at date is in the future' do
+      let(:expires_at) { today + 1.year }
+
+      it 'is valid' do
+        expect(framework.valid?(:update)).to eq true
+      end
+    end
+
+    context 'when the expires at date is the same as the live at date' do
+      let(:expires_at) { today }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:expires_at].first).to eq "The 'expires at' date must be after the 'live at' date"
+      end
+    end
+
+    context 'when the expires at date is before the live at date' do
+      let(:expires_at) { today - 2.days }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:expires_at].first).to eq "The 'expires at' date must be after the 'live at' date"
+      end
+    end
+  end
 end
+# rubocop:enable RSpec/NestedGroups

--- a/spec/support/framework_status.rb
+++ b/spec/support/framework_status.rb
@@ -6,10 +6,18 @@ RSpec.shared_context 'and RM6238 is live today' do
   before { Framework.find_by(framework: 'RM6238').update(live_at: Time.zone.now) }
 end
 
+RSpec.shared_context 'and RM3826 has expired' do
+  before { Framework.find_by(framework: 'RM3826').update(expires_at: Time.zone.now) }
+end
+
 RSpec.shared_context 'and RM6240 is live in the future' do
   before { Framework.find_by(framework: 'RM6240').update(live_at: Time.zone.now + 1.day) }
 end
 
 RSpec.shared_context 'and RM6240 is live today' do
   before { Framework.find_by(framework: 'RM6240').update(live_at: Time.zone.now) }
+end
+
+RSpec.shared_context 'and RM3788 has expired' do
+  before { Framework.find_by(framework: 'RM3788').update(expires_at: Time.zone.now) }
 end


### PR DESCRIPTION
Ticket: [FMFR-1224](https://crowncommercialservice.atlassian.net/browse/FMFR-1224)

After a recent discussion, it was realised that the way this was set up was incorrect. We need to allow multiple frameworks to be live at the same time. The changes I’ve made here match what is already present in FM.

In addition, I’ve updated the specs and feature tests accordingly.