### PR TITLE
FMFR-1202 - Fix issue where percentage prices were not imported correctly

### DIFF
--- a/app/helpers/supply_teachers/rm6238/suppliers_helper.rb
+++ b/app/helpers/supply_teachers/rm6238/suppliers_helper.rb
@@ -5,7 +5,7 @@ module SupplyTeachers::RM6238::SuppliersHelper
 
   def master_vendor_rate_cell(rate)
     rate_value = if rate.percentage?
-                   number_to_percentage(rate.rate, precision: 1)
+                   number_to_percentage(rate.value, precision: 1)
                  else
                    format_money(rate.value)
                  end

--- a/app/services/supply_teachers/rm6238/admin/data_import/generate_pricing.rb
+++ b/app/services/supply_teachers/rm6238/admin/data_import/generate_pricing.rb
@@ -53,10 +53,19 @@ module SupplyTeachers
         def clean_up_pricing_data(row, lot_number)
           row = remove_unused_keys(row)
           row[:job_type] = :agency_management if row[:job_type] == :agency_management_daily || row[:job_type] == :agency_management_long_term
-          row[:fee] = (row[:fee] * 100).to_i
+          row[:fee] = (row[:fee] * if percentage?(row)
+                                     10000
+                                   else
+                                     100
+                                   end).to_i
+
           row[:lot_number] = lot_number
 
           row
+        end
+
+        def percentage?(row)
+          row[:job_type] == :fixed_term || (row[:job_type] == :over_12_week && row[:term] == :daily)
         end
       end
     end

--- a/spec/helpers/supply_teachers/rm6238/suppliers_helper_spec.rb
+++ b/spec/helpers/supply_teachers/rm6238/suppliers_helper_spec.rb
@@ -37,18 +37,18 @@ RSpec.describe SupplyTeachers::RM6238::SuppliersHelper, type: :helper do
     let(:result) { helper.master_vendor_rate_cell(rate) }
 
     context 'when the rate is a percentage' do
-      let(:rate) { create(:supply_teachers_rm6238_master_vendor_below_threshold_rate, job_type: 'fixed_term') }
+      let(:rate) { create(:supply_teachers_rm6238_master_vendor_below_threshold_rate, job_type: 'fixed_term', rate: 4321) }
 
       it 'returns the rate as a percentage' do
-        expect(result).to include '30.0%'
+        expect(result).to include '43.2%'
       end
     end
 
     context 'when the rate is not a percentage' do
-      let(:rate) { create(:supply_teachers_rm6238_master_vendor_below_threshold_rate) }
+      let(:rate) { create(:supply_teachers_rm6238_master_vendor_below_threshold_rate, rate: 4321) }
 
       it 'returns the rate as a percentage' do
-        expect(result).to include '£0.30'
+        expect(result).to include '£43.21'
       end
     end
   end


### PR DESCRIPTION
Ticket: [FMR-1202](https://crowncommercialservice.atlassian.net/browse/FMFR-1202)

Fix issue where percentage prices were not imported correctly.

In excel, percentages are stored as decimal points (0.25 = 25%). Therefor, for our rates model we need to times this by 10,000, instead of 100 which is what was happening. For example, 0.025 -> 250 -> 2.5%.