### PR TITLE
FMFR-1148 - Add the education tech platforms results

### DIFF
--- a/app/controllers/supply_teachers/rm6238/suppliers_controller.rb
+++ b/app/controllers/supply_teachers/rm6238/suppliers_controller.rb
@@ -12,6 +12,11 @@ module SupplyTeachers
         @suppliers = Supplier.with_master_vendor_rates(threshold_position)
       end
 
+      def education_technology_platform_vendors
+        @back_path = source_journey.previous_step_path
+        @suppliers = Supplier.with_education_technology_platforms_rates
+      end
+
       private
 
       def threshold_position

--- a/app/helpers/supply_teachers/rm6238/suppliers_helper.rb
+++ b/app/helpers/supply_teachers/rm6238/suppliers_helper.rb
@@ -3,7 +3,7 @@ module SupplyTeachers::RM6238::SuppliersHelper
     supplier.managed_service_providers.find_by(lot_number: lot_number)
   end
 
-  def master_vendor_rate_cell(rate)
+  def managed_service_provider_rate_cell(rate)
     rate_value = if rate.percentage?
                    number_to_percentage(rate.value, precision: 1)
                  else
@@ -13,9 +13,9 @@ module SupplyTeachers::RM6238::SuppliersHelper
     tag.td(rate_value, class: 'govuk-table__cell govuk-table__cell--numeric master-vendor-record__markup-column')
   end
 
-  def master_vendor_sorted_rates(rates)
-    rates.sort_by { |rate| MASTER_VENDOR_SORT_ORDER.index(rate.tenure_type) }
+  def managed_service_provider_sorted_rates(rates)
+    rates.sort_by { |rate| MANAGED_SERVICE_PROVIDER_SORT_ORDER.index(rate.tenure_type) }
   end
 
-  MASTER_VENDOR_SORT_ORDER = %w[daily six_weeks_plus].freeze
+  MANAGED_SERVICE_PROVIDER_SORT_ORDER = %w[daily six_weeks_plus].freeze
 end

--- a/app/models/supply_teachers/rm6238/journey/education_technology_platform_vendors.rb
+++ b/app/models/supply_teachers/rm6238/journey/education_technology_platform_vendors.rb
@@ -1,0 +1,7 @@
+module SupplyTeachers
+  module RM6238
+    class Journey::EducationTechnologyPlatformVendors
+      include Steppable
+    end
+  end
+end

--- a/app/models/supply_teachers/rm6238/journey/managed_service_provider.rb
+++ b/app/models/supply_teachers/rm6238/journey/managed_service_provider.rb
@@ -13,7 +13,7 @@ module SupplyTeachers
         when 'master_vendor'
           Journey::MasterVendorOptions
         when 'education_technology_platform'
-          # Journey::EducationTechnologyPlatformService
+          Journey::EducationTechnologyPlatformVendors
         end
       end
     end

--- a/app/views/supply_teachers/rm6238/suppliers/_education_technology_platform_vendor.html.erb
+++ b/app/views/supply_teachers/rm6238/suppliers/_education_technology_platform_vendor.html.erb
@@ -1,0 +1,50 @@
+<div class="education-technology-platform-vendor-record">
+  <h2 class="govuk-heading-m"><%= education_technology_platform_vendor.name %></h2>
+
+  <% education_technology_platform_vendor_contact = managed_service_provider_contact(education_technology_platform_vendor, '4')%>
+
+  <% if education_technology_platform_vendor_contact.present? %>
+    <p class="govuk-body">
+      <span class="education-technology-platform-vendor-contact-details__name">
+        <strong><%= education_technology_platform_vendor_contact.contact_name %></strong>
+      </span>
+      <br />
+      <span class="education-technology-platform-vendor-contact-details__telephone">
+        <%= format_telephone_number(education_technology_platform_vendor_contact.telephone_number) %>
+      </span>
+      <br />
+      <span class="education-technology-platform-vendor-contact-details__email">
+        <%= mail_to(education_technology_platform_vendor_contact.contact_email,
+                   education_technology_platform_vendor_contact.contact_email,
+                   aria: {
+                     label: "Email #{education_technology_platform_vendor_contact.contact_name} from #{education_technology_platform_vendor.name}"
+                   }) %>
+      </span>
+    </p>
+  <% end %>
+
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><strong><%= t('.column1') %></strong></th>
+        <th class="govuk-table__header govuk-table__header--numeric education-technology-platform-vendor-record__markup-column" scope="col"><strong><%= t('.column2') %></strong></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% education_technology_platform_vendor.education_technology_platforms_rates_grouped_by_job_type.each do |job_type, rates| %>
+        <% rates.each do |rate| %>
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="row">
+              <% if rates.length == 1 %>
+                <%= SupplyTeachers::RM6238::JobType[job_type] %>
+              <% else %>
+                <%= t(".agency_management.#{rate.tenure_type}") %>
+              <% end %>
+            </th>
+            <%= managed_service_provider_rate_cell(rate) %>
+          </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/supply_teachers/rm6238/suppliers/_master_vendor.html.erb
+++ b/app/views/supply_teachers/rm6238/suppliers/_master_vendor.html.erb
@@ -7,14 +7,18 @@
     <p class="govuk-body">
       <span class="master-vendor-contact-details__name">
         <strong><%= master_vendor_contact.contact_name %></strong>
-      </span><br />
+      </span>
+      <br />
       <span class="master-vendor-contact-details__telephone">
         <%= format_telephone_number(master_vendor_contact.telephone_number) %>
-      </span><br />
+      </span>
+      <br />
       <span class="master-vendor-contact-details__email">
         <%= mail_to(master_vendor_contact.contact_email,
                    master_vendor_contact.contact_email,
-                   'aria-label': "Email #{master_vendor_contact.contact_name} from #{master_vendor.name}") %>
+                   aria: {
+                     label: "Email #{master_vendor_contact.contact_name} from #{master_vendor.name}"
+                   }) %>
       </span>
     </p>
   <% end %>
@@ -34,12 +38,12 @@
           <% if rates.length == 1 %>
             <% rates.each do |rate| %>
               <% 2.times do %>
-                <%= master_vendor_rate_cell(rate) %>
+                <%= managed_service_provider_rate_cell(rate) %>
               <% end %>
             <% end %>
           <% elsif rates.length == 2 %>
-            <% master_vendor_sorted_rates(rates).each do |rate| %>
-              <%= master_vendor_rate_cell(rate) %>
+            <% managed_service_provider_sorted_rates(rates).each do |rate| %>
+              <%= managed_service_provider_rate_cell(rate) %>
             <% end %>
           <% end %>
         </tr>

--- a/app/views/supply_teachers/rm6238/suppliers/education_technology_platform_vendors.html.erb
+++ b/app/views/supply_teachers/rm6238/suppliers/education_technology_platform_vendors.html.erb
@@ -1,0 +1,19 @@
+<%= content_for :page_title, t('.page_title') %>
+<%= content_for :page_section, t('supply_teachers.rm6238.page_section') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t('.header') %>
+    </h1>
+
+    <%= govuk_details(t('.do_next.header'), classes: 'govuk-!-margin-bottom-5') do %>
+      <p>
+        <%= t('.do_next.what_to_do') %>
+      </p>
+    <% end %>
+
+    <p class="govuk-body"><%= number_to_human(@suppliers.count, units: :suppliers) %></p>
+    <%= render partial: 'education_technology_platform_vendor', collection: @suppliers %>
+  </div>
+</div>

--- a/config/locales/views/supply_teachers.en.yml
+++ b/config/locales/views/supply_teachers.en.yml
@@ -626,6 +626,18 @@ en:
           question_hint: DESCRIPTION TO EXPLAIN OPTIONS
       page_section: Find supply teachers and agency staff
       suppliers:
+        education_technology_platform_vendor:
+          agency_management:
+            daily: 'Agency Management Fee: Daily supply worker (per worker, per day)'
+            six_weeks_plus: 'Agency Management Fee: Long term assignment (6 weeks+) (per worker, per day)'
+          column1: Job type
+          column2: Supplier fee
+        education_technology_platform_vendors:
+          do_next:
+            header: What to do next
+            what_to_do: WHAT TO DO NEXT
+          header: Education technology platform service providers
+          page_title: Education technology platform service providers
         master_vendor:
           column1: Job type
           column2: Supplier fee

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,7 @@ Rails.application.routes.draw do
       resources :suppliers, path: '/', only: %i[] do
         collection do
           get '/master-vendors', action: :master_vendors
+          get '/education-technology-platform-vendors', action: :education_technology_platform_vendors
         end
       end
 

--- a/spec/controllers/supply_teachers/rm6238/suppliers_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/suppliers_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SupplyTeachers::RM6238::SuppliersController, type: :controller do
       expect(assigns(:suppliers)).to eq(suppliers)
     end
 
-    it 'sets the back path to the managed-service-provider question' do
+    it 'sets the back path to the master-vendor-options question' do
       expected_path = journey_question_path(
         journey: 'supply-teachers',
         slug: 'master-vendor-options',
@@ -46,6 +46,37 @@ RSpec.describe SupplyTeachers::RM6238::SuppliersController, type: :controller do
         expect(response).to render_template('supply_teachers/home/unrecognised_framework')
         expect(response).to have_http_status(:bad_request)
       end
+    end
+  end
+
+  describe 'GET education_technology_platform_vendors' do
+    let(:supplier) { build(:supply_teachers_rm6238_supplier) }
+    let(:suppliers) { [supplier] }
+
+    before do
+      allow(SupplyTeachers::RM6238::Supplier).to receive(:with_education_technology_platforms_rates).and_return(suppliers)
+
+      get :education_technology_platform_vendors, params: {
+        looking_for: 'managed_service_provider', managed_service_provider: 'education_technology_platform'
+      }
+    end
+
+    it 'renders the education_technology_platform_vendors template' do
+      expect(response).to render_template('education_technology_platform_vendors')
+    end
+
+    it 'assigns suppliers with education technology platform vendor rates to suppliers' do
+      expect(assigns(:suppliers)).to eq(suppliers)
+    end
+
+    it 'sets the back path to the managed-service-provider question' do
+      expected_path = journey_question_path(
+        journey: 'supply-teachers',
+        slug: 'managed-service-provider',
+        looking_for: 'managed_service_provider',
+        managed_service_provider: 'education_technology_platform'
+      )
+      expect(assigns(:back_path)).to eq(expected_path)
     end
   end
 end

--- a/spec/helpers/supply_teachers/rm6238/suppliers_helper_spec.rb
+++ b/spec/helpers/supply_teachers/rm6238/suppliers_helper_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe SupplyTeachers::RM6238::SuppliersHelper, type: :helper do
     end
   end
 
-  describe '.master_vendor_rate_cell' do
-    let(:result) { helper.master_vendor_rate_cell(rate) }
+  describe '.managed_service_provider_rate_cell' do
+    let(:result) { helper.managed_service_provider_rate_cell(rate) }
 
     context 'when the rate is a percentage' do
       let(:rate) { create(:supply_teachers_rm6238_master_vendor_below_threshold_rate, job_type: 'fixed_term', rate: 4321) }
@@ -53,7 +53,7 @@ RSpec.describe SupplyTeachers::RM6238::SuppliersHelper, type: :helper do
     end
   end
 
-  describe '.master_vendor_sorted_rates' do
+  describe '.managed_service_provider_sorted_rates' do
     let(:supplier) { create(:supply_teachers_rm6238_supplier) }
 
     let(:rate1) { create(:supply_teachers_rm6238_master_vendor_below_threshold_rate, supplier: supplier, job_type: 'teacher', tenure_type: 'daily') }
@@ -65,7 +65,7 @@ RSpec.describe SupplyTeachers::RM6238::SuppliersHelper, type: :helper do
     end
 
     it 'sorts the rates by the job tyoe' do
-      expect(helper.master_vendor_sorted_rates(supplier.rates)).to eq [
+      expect(helper.managed_service_provider_sorted_rates(supplier.rates)).to eq [
         rate1,
         rate2
       ]

--- a/spec/models/supply_teachers/rm6238/journey/education_technology_platform_vendors_spec.rb
+++ b/spec/models/supply_teachers/rm6238/journey/education_technology_platform_vendors_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe SupplyTeachers::RM6238::Journey::EducationTechnologyPlatformVendors, type: :model do
+  subject(:step) { described_class.new(managed_service_provider: 'education_technology_platform') }
+
+  it { is_expected.to be_valid }
+
+  describe '.final?' do
+    it 'returns true' do
+      expect(step.final?).to be true
+    end
+  end
+end

--- a/spec/models/supply_teachers/rm6238/journey/managed_service_provider_spec.rb
+++ b/spec/models/supply_teachers/rm6238/journey/managed_service_provider_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe SupplyTeachers::RM6238::Journey::ManagedServiceProvider, type: :m
     context 'when managed_service_provider is education_technology_platform' do
       let(:managed_service_provider) { 'education_technology_platform' }
 
-      pending 'returns Journey::EducationTechnologyPlatformService' do
-        expect(step.next_step_class).to be SupplyTeachers::RM6238::Journey::EducationTechnologyPlatformService
+      it 'returns Journey::EducationTechnologyPlatformVendors' do
+        expect(step.next_step_class).to be SupplyTeachers::RM6238::Journey::EducationTechnologyPlatformVendors
       end
     end
   end


### PR DESCRIPTION
Ticket: [FMR-1148](https://crowncommercialservice.atlassian.net/browse/FMFR-1148)

In this commit I have added the results page for the Education Technology Platform vendors.

I have also added specs for the new models and controllers created as part of this journey.

I will add the feature tests in the next commit now that the managed service providers journey is completed.