### PR TITLE
FMFR-1204 - Add supplier spreadsheet

### DIFF
--- a/app/controllers/supply_teachers/branches_controller.rb
+++ b/app/controllers/supply_teachers/branches_controller.rb
@@ -38,7 +38,7 @@ module SupplyTeachers
         format.js { render json: @branches.find { |branch| rate_params(step.class.name.include?('FixedTermResults'))[branch.id].present? } }
         format.html
         format.xlsx do
-          spreadsheet = service_name::Spreadsheet.new(@branches, with_calculations: params[:calculations].present?)
+          spreadsheet = Spreadsheet.new(@branches, with_calculations: params[:calculations].present?)
           filename = "Shortlist of agencies#{params[:calculations].present? ? ' (with calculator)' : ''}.xlsx"
           send_data spreadsheet.to_xlsx, filename: filename, type: :xlsx
         end

--- a/app/models/supply_teachers/spreadsheet.rb
+++ b/app/models/supply_teachers/spreadsheet.rb
@@ -1,4 +1,4 @@
-class SupplyTeachers::RM3826::Spreadsheet
+class SupplyTeachers::Spreadsheet
   class DataDownload
     include TelephoneNumberHelper
 

--- a/spec/controllers/supply_teachers/rm3826/branches_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm3826/branches_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe SupplyTeachers::RM3826::BranchesController, type: :controller do
       end
 
       it 'responds to requests for spreadsheets' do
-        allow(SupplyTeachers::RM3826::Spreadsheet)
+        allow(SupplyTeachers::Spreadsheet)
           .to receive(:new)
           .and_return(instance_double('Spreadsheet', to_xlsx: 'spreadsheet-data'))
 

--- a/spec/controllers/supply_teachers/rm6238/branches_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/branches_controller_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe SupplyTeachers::RM6238::BranchesController, type: :controller do
         expect(response.media_type).to eq 'text/html'
       end
 
-      pending 'responds to requests for spreadsheets' do
-        allow(SupplyTeachers::RM6238::Spreadsheet)
+      it 'responds to requests for spreadsheets' do
+        allow(SupplyTeachers::Spreadsheet)
           .to receive(:new)
           .and_return(instance_double('Spreadsheet', to_xlsx: 'spreadsheet-data'))
 

--- a/spec/models/supply_teachers/spreadsheet_spec.rb
+++ b/spec/models/supply_teachers/spreadsheet_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SupplyTeachers::RM3826::Spreadsheet do
+RSpec.describe SupplyTeachers::Spreadsheet do
   let(:telephone_number) { '0121 496 0123' }
   let(:branch1) { build(:supply_teachers_branch_search_result, telephone_number: telephone_number) }
   let(:branch2) { build(:supply_teachers_branch_search_result, telephone_number: '029 2018 0999') }


### PR DESCRIPTION
Ticket: [FMR-1204](https://crowncommercialservice.atlassian.net/browse/FMFR-1204)

In this commit I have added the ability to download the spreadsheet of the supplier results. It turns out that the spreadsheet we generate is identical to the one for the previous framework so we didn’t need to create any new code (just share the code).

In the next PR I will add the feature tests for this part of the supplier journey.