### PR TITLE
FMFR-1209 - Create legal services RM6240 models

### DIFF
--- a/app/models/legal_services/rm6240.rb
+++ b/app/models/legal_services/rm6240.rb
@@ -1,0 +1,7 @@
+module LegalServices
+  module RM6240
+    def self.table_name_prefix
+      'legal_services_rm6240_'
+    end
+  end
+end

--- a/app/models/legal_services/rm6240/jurisdiction.rb
+++ b/app/models/legal_services/rm6240/jurisdiction.rb
@@ -1,0 +1,19 @@
+module LegalServices
+  module RM6240
+    class Jurisdiction
+      include StaticRecord
+
+      attr_accessor :code, :name
+
+      def self.[](code)
+        Jurisdiction.find_by(code: code)
+      end
+
+      def self.all_codes
+        all.map(&:code)
+      end
+    end
+
+    Jurisdiction.load_csv('legal_services/rm6240/jurisdictions.csv')
+  end
+end

--- a/app/models/legal_services/rm6240/lot.rb
+++ b/app/models/legal_services/rm6240/lot.rb
@@ -1,0 +1,19 @@
+module LegalServices
+  module RM6240
+    class Lot
+      include StaticRecord
+
+      attr_accessor :number, :description
+
+      def self.[](number)
+        Lot.find_by(number: number)
+      end
+
+      def self.all_numbers
+        all.map(&:number)
+      end
+    end
+
+    Lot.load_csv('legal_services/rm6240/lots.csv')
+  end
+end

--- a/app/models/legal_services/rm6240/position.rb
+++ b/app/models/legal_services/rm6240/position.rb
@@ -1,0 +1,19 @@
+module LegalServices
+  module RM6240
+    class Position
+      include StaticRecord
+
+      attr_accessor :code, :name
+
+      def self.[](code)
+        Position.find_by(code: code)
+      end
+
+      def self.all_codes
+        all.map(&:code)
+      end
+    end
+
+    Position.load_csv('legal_services/rm6240/position.csv')
+  end
+end

--- a/app/models/legal_services/rm6240/rate.rb
+++ b/app/models/legal_services/rm6240/rate.rb
@@ -1,0 +1,37 @@
+module LegalServices
+  module RM6240
+    class Rate < ApplicationRecord
+      belongs_to :supplier,
+                 foreign_key: :legal_services_rm6240_supplier_id,
+                 inverse_of: :rates
+
+      validates :lot_number,
+                presence: true,
+                uniqueness: { scope: %i[supplier jurisdiction position] },
+                inclusion: { in: Lot.all_numbers }
+
+      validates :jurisdiction,
+                presence: { if: :jurisdiction_required? },
+                absence: { unless: :jurisdiction_required? },
+                inclusion: { in: Jurisdiction.all_codes, allow_blank: true }
+
+      validates :position,
+                presence: true,
+                inclusion: { in: Position.all_codes }
+
+      validates :rate,
+                presence: true,
+                numericality: { only_integer: true }
+
+      def value
+        rate / 100.0
+      end
+
+      private
+
+      def jurisdiction_required?
+        lot_number != '3'
+      end
+    end
+  end
+end

--- a/app/models/legal_services/rm6240/service.rb
+++ b/app/models/legal_services/rm6240/service.rb
@@ -1,0 +1,27 @@
+module LegalServices
+  module RM6240
+    class Service
+      include Virtus.model
+      include StaticRecord
+
+      attribute :lot_number, String
+      attribute :service_number, String
+      attribute :name, String
+      attribute :central_government, Axiom::Types::Boolean
+
+      def self.all_service_code
+        all.map(&:service_code)
+      end
+
+      def self.services_for_lot(lot_number)
+        where(lot_number: lot_number)
+      end
+
+      def service_code
+        "#{lot_number}.#{service_number}"
+      end
+    end
+
+    Service.load_csv('legal_services/rm6240/services.csv')
+  end
+end

--- a/app/models/legal_services/rm6240/service_offering.rb
+++ b/app/models/legal_services/rm6240/service_offering.rb
@@ -1,0 +1,29 @@
+module LegalServices
+  module RM6240
+    class ServiceOffering < ApplicationRecord
+      belongs_to :supplier,
+                 foreign_key: :legal_services_rm6240_supplier_id,
+                 inverse_of: :service_offerings
+
+      validates :service_code,
+                presence: true,
+                uniqueness: { scope: %i[supplier jurisdiction] },
+                inclusion: { in: Service.all_service_code }
+
+      validates :jurisdiction,
+                presence: { if: :jurisdiction_required? },
+                absence: { unless: :jurisdiction_required? },
+                inclusion: { in: Jurisdiction.all_codes, allow_blank: true }
+
+      def self.supplier_ids_for_service_codes_and_jurisdiction(service_codes, jurisdiction = nil)
+        where(service_code: service_codes, jurisdiction: jurisdiction).distinct.pluck(:legal_services_rm6240_supplier_id)
+      end
+
+      private
+
+      def jurisdiction_required?
+        service_code != '3.1'
+      end
+    end
+  end
+end

--- a/app/models/legal_services/rm6240/supplier.rb
+++ b/app/models/legal_services/rm6240/supplier.rb
@@ -1,0 +1,28 @@
+module LegalServices
+  module RM6240
+    class Supplier < ApplicationRecord
+      has_many :service_offerings,
+               foreign_key: :legal_services_rm6240_supplier_id,
+               inverse_of: :supplier,
+               dependent: :destroy
+
+      has_many :rates,
+               foreign_key: :legal_services_rm6240_supplier_id,
+               inverse_of: :supplier,
+               dependent: :destroy
+
+      validates :name, presence: true
+
+      def self.offering_services_in_jurisdiction(lot_number, service_numbers, jurisdiction = nil)
+        valid_service_codes = set_service_codes(lot_number, service_numbers)
+
+        ids = ServiceOffering.supplier_ids_for_service_codes_and_jurisdiction(valid_service_codes, jurisdiction)
+        where(id: ids)
+      end
+
+      def self.set_service_codes(lot_number, service_numbers)
+        Service.where(lot_number: lot_number, service_number: service_numbers).map(&:service_code)
+      end
+    end
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,4 +16,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'RM3788'
   inflect.acronym 'RM3826'
   inflect.acronym 'RM6238'
+  inflect.acronym 'RM6240'
 end

--- a/data/legal_services/rm6240/jurisdictions.csv
+++ b/data/legal_services/rm6240/jurisdictions.csv
@@ -1,0 +1,4 @@
+code,name
+a,England & Wales
+b,Scotland
+c,Northern Ireland

--- a/data/legal_services/rm6240/lots.csv
+++ b/data/legal_services/rm6240/lots.csv
@@ -1,0 +1,4 @@
+number,description
+1,Full service provision
+2,General service provision
+3,Transport rail legal services

--- a/data/legal_services/rm6240/position.csv
+++ b/data/legal_services/rm6240/position.csv
@@ -1,0 +1,7 @@
+code,name
+1,Partner
+2,"Senior Solicitor, Senior Associate"
+3,"Solicitor, Associate"
+4,"NQ Solicitor/Associate, Junior Solicitor/Associate"
+5,Trainee
+6,"Paralegal, Legal Assistant"

--- a/data/legal_services/rm6240/services.csv
+++ b/data/legal_services/rm6240/services.csv
@@ -1,0 +1,57 @@
+lot_number,service_number,name,central_government
+1,1,Administrative and Public Law,TRUE
+1,2,Non-Complex Finance and Investment,TRUE
+1,3,Contracts,TRUE
+1,4,Competition Law,FALSE
+1,5,Corporate Law,FALSE
+1,6,Data Protection and Information Law,FALSE
+1,7,Employment,TRUE
+1,8,Information Technology ,TRUE
+1,9,Infrastructure,FALSE
+1,10,Intellectual Property,FALSE
+1,11,Litigation and Dispute Resolution,FALSE
+1,12,Partnerships,FALSE
+1,13,Pensions,FALSE
+1,14,Public Procurement,FALSE
+1,15,"Property, Real Estate and Construction",FALSE
+1,16,"Energy, Natural Resources and Climate Change",FALSE
+1,17,Retained EU Law and EU Law,FALSE
+1,18,Planning,FALSE
+1,19,Projects,FALSE
+1,20,Restructuring and Insolvency,FALSE
+1,21,Education Law,FALSE
+1,22,Children and Vulnerable Adults,FALSE
+1,23,"Food, Rural and Environmental Affairs",FALSE
+1,24,Franchise Law,FALSE
+1,25,"Health, Healthcare and Social Care",FALSE
+1,26,Life Sciences,FALSE
+1,27,Telecommunications,FALSE
+1,28,"International Trade, Investment and Regulation",FALSE
+1,29,Public International Law,FALSE
+1,30,Charities Law,FALSE
+1,31,Health and Safety,FALSE
+1,32,Licensing Law,FALSE
+1,33,Transport Law (excluding Rail),FALSE
+1,34,Tax,FALSE
+1,35,Outsourcing / Insourcing,FALSE
+1,36,Islamic Finance / Sukuk,FALSE
+1,37,Media Law,FALSE
+1,38,Immigration,FALSE
+1,39,Public Inquests and Inquiries ,FALSE
+1,40,Mental Health Law,FALSE
+2,1,Property and Construction ,FALSE
+2,2,Social Housing,FALSE
+2,3,Child Law,FALSE
+2,4,Court of Protection,FALSE
+2,5,Education Law,FALSE
+2,6,Debt Recovery,FALSE
+2,7,Planning and Environment,FALSE
+2,8,Licensing,FALSE
+2,9,Pensions,FALSE
+2,10,Litigation / Dispute Resolution,FALSE
+2,11,Intellectual Property,FALSE
+2,12,Employment,FALSE
+2,13,Healthcare,FALSE
+2,14,Primary Care,FALSE
+2,15,Mental Health Law,FALSE
+3,1,Transport (Rail),FALSE

--- a/db/migrate/20220725141935_add_legal_services_tables.rb
+++ b/db/migrate/20220725141935_add_legal_services_tables.rb
@@ -1,0 +1,40 @@
+class AddLegalServicesTables < ActiveRecord::Migration[6.0]
+  # rubocop:disable Metrics/AbcSize
+  def change
+    create_table :legal_services_rm6240_suppliers, id: :uuid do |t|
+      t.text :name, null: false
+      t.text :email
+      t.text :phone_number
+      t.text :website
+      t.text :address
+      t.boolean :sme
+      t.integer :duns
+      t.text :lot_1_prospectus_link
+      t.text :lot_2_prospectus_link
+      t.text :lot_3_prospectus_link
+
+      t.timestamps
+    end
+
+    create_table :legal_services_rm6240_service_offerings, id: :uuid do |t|
+      t.references :legal_services_rm6240_supplier, type: :uuid, foreign_key: true, index: { name: :index_ls_rm6240_service_offerings_on_ls_rm6240_supplier_id }
+      t.string :service_code, limit: 4, null: false
+      t.string :jurisdiction, limit: 1
+      t.index %i[legal_services_rm6240_supplier_id service_code jurisdiction], unique: true, name: :index_rates_on_supplier_id_and_service_code_and_jurisdiction
+
+      t.timestamps
+    end
+
+    create_table :legal_services_rm6240_rates, id: :uuid do |t|
+      t.references :legal_services_rm6240_supplier, type: :uuid, foreign_key: true, index: { name: :index_ls_rm6240_rates_on_ls_rm6240_supplier_id }
+      t.string :lot_number, limit: 1, null: false
+      t.string :jurisdiction, limit: 1
+      t.string :position, limit: 1, null: false
+      t.integer :rate, null: false
+      t.index %i[legal_services_rm6240_supplier_id lot_number jurisdiction position], unique: true, name: :index_rates_on_supplier_id_lot_number_position_jurisdiction
+
+      t.timestamps
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_20_084351) do
+ActiveRecord::Schema.define(version: 2022_07_25_141935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -100,6 +100,43 @@ ActiveRecord::Schema.define(version: 2022_07_20_084351) do
   create_table "legal_services_rm3788_uploads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "legal_services_rm6240_rates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "legal_services_rm6240_supplier_id"
+    t.string "lot_number", limit: 1, null: false
+    t.string "jurisdiction", limit: 1
+    t.string "position", limit: 1, null: false
+    t.integer "rate", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["legal_services_rm6240_supplier_id", "lot_number", "jurisdiction", "position"], name: "index_rates_on_supplier_id_lot_number_position_jurisdiction", unique: true
+    t.index ["legal_services_rm6240_supplier_id"], name: "index_ls_rm6240_rates_on_ls_rm6240_supplier_id"
+  end
+
+  create_table "legal_services_rm6240_service_offerings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "legal_services_rm6240_supplier_id"
+    t.string "service_code", limit: 4, null: false
+    t.string "jurisdiction", limit: 1
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["legal_services_rm6240_supplier_id", "service_code", "jurisdiction"], name: "index_rates_on_supplier_id_and_service_code_and_jurisdiction", unique: true
+    t.index ["legal_services_rm6240_supplier_id"], name: "index_ls_rm6240_service_offerings_on_ls_rm6240_supplier_id"
+  end
+
+  create_table "legal_services_rm6240_suppliers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "name", null: false
+    t.text "email"
+    t.text "phone_number"
+    t.text "website"
+    t.text "address"
+    t.boolean "sme"
+    t.integer "duns"
+    t.text "lot_1_prospectus_link"
+    t.text "lot_2_prospectus_link"
+    t.text "lot_3_prospectus_link"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "management_consultancy_rm6187_admin_uploads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -330,6 +367,8 @@ ActiveRecord::Schema.define(version: 2022_07_20_084351) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "legal_services_rm3788_regional_availabilities", "legal_services_rm3788_suppliers"
   add_foreign_key "legal_services_rm3788_service_offerings", "legal_services_rm3788_suppliers"
+  add_foreign_key "legal_services_rm6240_rates", "legal_services_rm6240_suppliers"
+  add_foreign_key "legal_services_rm6240_service_offerings", "legal_services_rm6240_suppliers"
   add_foreign_key "management_consultancy_rm6187_rate_cards", "management_consultancy_rm6187_suppliers"
   add_foreign_key "management_consultancy_rm6187_service_offerings", "management_consultancy_rm6187_suppliers"
   add_foreign_key "supply_teachers_rm3826_branches", "supply_teachers_rm3826_suppliers"

--- a/spec/factories/legal_services/rm6240/rate.rb
+++ b/spec/factories/legal_services/rm6240/rate.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :legal_services_rm6240_rate, class: 'LegalServices::RM6240::Rate' do
+    association :supplier, factory: :legal_services_rm6240_supplier
+    rate { 3000 }
+    position { '1' }
+  end
+
+  factory :legal_services_rm6240_full_service_provision_rate, parent: :legal_services_rm6240_rate do
+    lot_number { '1' }
+    jurisdiction { 'a' }
+  end
+
+  factory :legal_services_rm6240_general_service_provision_rate, parent: :legal_services_rm6240_rate do
+    lot_number { '2' }
+    jurisdiction { 'b' }
+  end
+
+  factory :legal_services_rm6240_transport_rail_rate, parent: :legal_services_rm6240_rate do
+    lot_number { '3' }
+  end
+end

--- a/spec/factories/legal_services/rm6240/service_offering.rb
+++ b/spec/factories/legal_services/rm6240/service_offering.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :legal_services_rm6240_service_offering, class: 'LegalServices::RM6240::ServiceOffering' do
+    association :supplier, factory: :legal_services_rm6240_supplier
+  end
+
+  factory :legal_services_rm6240_full_service_provision_service_offering, parent: :legal_services_rm6240_service_offering do
+    service_code { '1.1' }
+    jurisdiction { 'a' }
+  end
+
+  factory :legal_services_rm6240_general_service_provision_service_offering, parent: :legal_services_rm6240_service_offering do
+    service_code { '2.1' }
+    jurisdiction { 'b' }
+  end
+
+  factory :legal_services_rm6240_transport_rail_service_offering, parent: :legal_services_rm6240_service_offering do
+    service_code { '3.1' }
+  end
+end

--- a/spec/factories/legal_services/rm6240/supplier.rb
+++ b/spec/factories/legal_services/rm6240/supplier.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :legal_services_rm6240_supplier, class: 'LegalServices::RM6240::Supplier' do
+    name { Faker::Name.unique.name }
+    email { Faker::Internet.unique.email }
+    phone_number { Faker::PhoneNumber.unique.phone_number }
+  end
+end

--- a/spec/models/legal_services/rm6240/jurisdiction_spec.rb
+++ b/spec/models/legal_services/rm6240/jurisdiction_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe LegalServices::RM6240::Jurisdiction, type: :model do
+  subject(:jurisdictions) { described_class.all }
+
+  let(:first_jurisdiction) { jurisdictions.first }
+  let(:all_codes) { described_class.all_codes }
+
+  it 'loads jurisdictions from CSV' do
+    expect(jurisdictions.count).to eq(3)
+  end
+
+  it 'populates attributes of first jurisdiction' do
+    expect(first_jurisdiction.code).to eq('a')
+    expect(first_jurisdiction.name).to eq('England & Wales')
+  end
+
+  it 'only has unique codes' do
+    expect(all_codes.uniq).to contain_exactly(*all_codes)
+  end
+
+  it 'all have names' do
+    expect(jurisdictions.select { |l| l.name.blank? }).to be_empty
+  end
+
+  describe '.[]' do
+    it 'looks up jurisdiction by code' do
+      expect(described_class['a'].code).to eq('a')
+    end
+  end
+
+  describe '.all_codes' do
+    it 'returns codes for all jurisdictions' do
+      expect(all_codes.count).to eq(jurisdictions.count)
+      expect(all_codes.first).to eq(first_jurisdiction.code)
+    end
+  end
+end

--- a/spec/models/legal_services/rm6240/lot_spec.rb
+++ b/spec/models/legal_services/rm6240/lot_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe LegalServices::RM6240::Lot, type: :model do
+  subject(:lots) { described_class.all }
+
+  let(:first_lot) { lots.first }
+  let(:all_numbers) { described_class.all_numbers }
+
+  it 'loads lots from CSV' do
+    expect(lots.count).to eq(3)
+  end
+
+  it 'populates attributes of first lot' do
+    expect(first_lot.number).to eq('1')
+    expect(first_lot.description).to eq('Full service provision')
+  end
+
+  it 'only has unique numbers' do
+    expect(all_numbers.uniq).to contain_exactly(*all_numbers)
+  end
+
+  it 'all have descriptions' do
+    expect(lots.select { |l| l.description.blank? }).to be_empty
+  end
+
+  describe '.[]' do
+    it 'looks up lot by number' do
+      expect(described_class['1'].number).to eq('1')
+    end
+  end
+
+  describe '.all_numbers' do
+    it 'returns numbers for all lots' do
+      expect(all_numbers.count).to eq(lots.count)
+      expect(all_numbers.first).to eq(first_lot.number)
+    end
+  end
+end

--- a/spec/models/legal_services/rm6240/position_spec.rb
+++ b/spec/models/legal_services/rm6240/position_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe LegalServices::RM6240::Position, type: :model do
+  subject(:positions) { described_class.all }
+
+  let(:first_position) { positions.first }
+  let(:all_codes) { described_class.all_codes }
+
+  it 'loads positions from CSV' do
+    expect(positions.count).to eq(6)
+  end
+
+  it 'populates attributes of first position' do
+    expect(first_position.code).to eq('1')
+    expect(first_position.name).to eq('Partner')
+  end
+
+  it 'only has unique codes' do
+    expect(all_codes.uniq).to contain_exactly(*all_codes)
+  end
+
+  it 'all have names' do
+    expect(positions.select { |l| l.name.blank? }).to be_empty
+  end
+
+  describe '.[]' do
+    it 'looks up position by code' do
+      expect(described_class['1'].code).to eq('1')
+    end
+  end
+
+  describe '.all_codes' do
+    it 'returns codes for all positions' do
+      expect(all_codes.count).to eq(positions.count)
+      expect(all_codes.first).to eq(first_position.code)
+    end
+  end
+end

--- a/spec/models/legal_services/rm6240/rate_spec.rb
+++ b/spec/models/legal_services/rm6240/rate_spec.rb
@@ -1,0 +1,223 @@
+require 'rails_helper'
+
+RSpec.describe LegalServices::RM6240::Rate, type: :model do
+  subject(:rate) { build(:legal_services_rm6240_full_service_provision_rate) }
+
+  it { is_expected.to be_valid }
+
+  # rubocop:disable RSpec/NestedGroups
+  describe 'validations' do
+    context 'when validating the lot number' do
+      before { rate.assign_attributes(lot_number: lot_number) }
+
+      context 'and it is blank' do
+        let(:lot_number) { nil }
+
+        it 'is not valid' do
+          expect(rate).not_to be_valid
+        end
+      end
+
+      context 'and it is not in the list of lot numbers' do
+        let(:lot_number) { '4' }
+
+        it 'is not valid' do
+          expect(rate).not_to be_valid
+        end
+      end
+    end
+
+    context 'when validating the jurisdiction' do
+      before { rate.assign_attributes(lot_number: lot_number, jurisdiction: jurisdiction) }
+
+      context 'and the lot requires it' do
+        let(:lot_number) { '2' }
+
+        context 'and it is blank' do
+          let(:jurisdiction) { nil }
+
+          it 'is not valid' do
+            expect(rate).not_to be_valid
+          end
+        end
+
+        context 'and it is not in the list of jurisdictions' do
+          let(:jurisdiction) { 'invalid-jurisdiction' }
+
+          it 'is not valid' do
+            expect(rate).not_to be_valid
+          end
+        end
+      end
+
+      context 'and lot does not require it' do
+        let(:lot_number) { '3' }
+
+        context 'and it is blank' do
+          let(:jurisdiction) { nil }
+
+          it 'is valid' do
+            expect(rate).to be_valid
+          end
+        end
+
+        context 'and it is not in the list of jurisdictions' do
+          let(:jurisdiction) { 'invalid-jurisdiction' }
+
+          it 'is not valid' do
+            expect(rate).not_to be_valid
+          end
+        end
+
+        context 'and it is in the list of jurisdictions' do
+          let(:jurisdiction) { 'a' }
+
+          it 'is not valid' do
+            expect(rate).not_to be_valid
+          end
+        end
+      end
+    end
+
+    context 'when validating the position' do
+      before { rate.assign_attributes(position: position) }
+
+      context 'and it is blank' do
+        let(:position) { nil }
+
+        it 'is not valid' do
+          expect(rate).not_to be_valid
+        end
+      end
+
+      context 'and it is not in the list of positions' do
+        let(:position) { '7' }
+
+        it 'is not valid' do
+          expect(rate).not_to be_valid
+        end
+      end
+    end
+
+    context 'when validating the rate' do
+      before { rate.assign_attributes(rate: rate_value) }
+
+      context 'and it is nil' do
+        let(:rate_value) { nil }
+
+        it 'is not valid' do
+          expect(rate).not_to be_valid
+        end
+      end
+
+      context 'and it is blank' do
+        let(:rate_value) { '' }
+
+        it 'is not valid' do
+          expect(rate).not_to be_valid
+        end
+      end
+
+      context 'and it is a string' do
+        let(:rate_value) { 'I am string' }
+
+        it 'is not valid' do
+          expect(rate).not_to be_valid
+        end
+      end
+
+      context 'and it is a float' do
+        let(:rate_value) { 12.5 }
+
+        it 'is not valid' do
+          expect(rate).not_to be_valid
+        end
+      end
+
+      context 'and it is an integer' do
+        let(:rate_value) { 45 }
+
+        it 'is valid' do
+          expect(rate).to be_valid
+        end
+      end
+    end
+
+    context 'when validating the uniqueness' do
+      let(:new_rate) do
+        build(
+          :legal_services_rm6240_rate,
+          supplier: supplier,
+          lot_number: lot_number,
+          jurisdiction: jurisdiction,
+          position: position
+        )
+      end
+      let(:supplier) { rate.supplier }
+      let(:lot_number) { rate.lot_number }
+      let(:jurisdiction) { rate.jurisdiction }
+      let(:position) { rate.position }
+
+      before { rate.save }
+
+      context 'when the supplier, lot_number, jurisdiction and position are the same' do
+        it 'is not valid' do
+          expect(new_rate).not_to be_valid
+        end
+      end
+
+      context 'when the supplier is different' do
+        let(:supplier) { build(:legal_services_rm6240_supplier) }
+
+        it 'is valid' do
+          expect(new_rate).to be_valid
+        end
+      end
+
+      context 'when the lot_number is different' do
+        let(:lot_number) { '2' }
+
+        it 'is valid' do
+          expect(new_rate).to be_valid
+        end
+      end
+
+      context 'when the jurisdiction is different' do
+        let(:jurisdiction) { 'b' }
+
+        it 'is valid' do
+          expect(new_rate).to be_valid
+        end
+      end
+
+      context 'when the position is different' do
+        let(:position) { '2' }
+
+        it 'is valid' do
+          expect(new_rate).to be_valid
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/NestedGroups
+
+  describe 'value' do
+    before { rate.assign_attributes(rate: rate_value) }
+
+    context 'and the rate value is 3550' do
+      let(:rate_value) { 3550 }
+
+      it 'returns 35.5' do
+        expect(rate.value).to eq 35.5
+      end
+    end
+
+    context 'and the rate value is 1200' do
+      let(:rate_value) { 1200 }
+
+      it 'returns 12.0' do
+        expect(rate.value).to eq 12.0
+      end
+    end
+  end
+end

--- a/spec/models/legal_services/rm6240/service_offering_spec.rb
+++ b/spec/models/legal_services/rm6240/service_offering_spec.rb
@@ -1,0 +1,188 @@
+require 'rails_helper'
+
+RSpec.describe LegalServices::RM6240::ServiceOffering, type: :model do
+  subject(:service_offering) { build(:legal_services_rm6240_full_service_provision_service_offering) }
+
+  it { is_expected.to be_valid }
+
+  # rubocop:disable RSpec/NestedGroups
+  describe 'validations' do
+    context 'when validating the service code' do
+      before { service_offering.assign_attributes(service_code: service_code) }
+
+      context 'and it is blank' do
+        let(:service_code) { nil }
+
+        it 'is not valid' do
+          expect(service_offering).not_to be_valid
+        end
+      end
+
+      context 'and it is not in the list of service codes' do
+        let(:service_code) { '1.99' }
+
+        it 'is not valid' do
+          expect(service_offering).not_to be_valid
+        end
+      end
+    end
+
+    context 'when validating the jurisdiction' do
+      before { service_offering.assign_attributes(service_code: service_code, jurisdiction: jurisdiction) }
+
+      context 'and the service requires it' do
+        let(:service_code) { '2.1' }
+
+        context 'and it is blank' do
+          let(:jurisdiction) { nil }
+
+          it 'is not valid' do
+            expect(service_offering).not_to be_valid
+          end
+        end
+
+        context 'and it is not in the list of jurisdictions' do
+          let(:jurisdiction) { 'invalid-jurisdiction' }
+
+          it 'is not valid' do
+            expect(service_offering).not_to be_valid
+          end
+        end
+      end
+
+      context 'and service does not require it' do
+        let(:service_code) { '3.1' }
+
+        context 'and it is blank' do
+          let(:jurisdiction) { nil }
+
+          it 'is valid' do
+            expect(service_offering).to be_valid
+          end
+        end
+
+        context 'and it is not in the list of jurisdictions' do
+          let(:jurisdiction) { 'invalid-jurisdiction' }
+
+          it 'is not valid' do
+            expect(service_offering).not_to be_valid
+          end
+        end
+
+        context 'and it is in the list of jurisdictions' do
+          let(:jurisdiction) { 'a' }
+
+          it 'is not valid' do
+            expect(service_offering).not_to be_valid
+          end
+        end
+      end
+    end
+
+    context 'when validating the uniqueness' do
+      let(:new_service_offering) do
+        build(
+          :legal_services_rm6240_service_offering,
+          supplier: supplier,
+          service_code: service_code,
+          jurisdiction: jurisdiction
+        )
+      end
+      let(:supplier) { service_offering.supplier }
+      let(:service_code) { service_offering.service_code }
+      let(:jurisdiction) { service_offering.jurisdiction }
+
+      before { service_offering.save }
+
+      context 'when the supplier, service_code and jurisdiction are the same' do
+        it 'is not valid' do
+          expect(new_service_offering).not_to be_valid
+        end
+      end
+
+      context 'when the supplier is different' do
+        let(:supplier) { build(:legal_services_rm6240_supplier) }
+
+        it 'is valid' do
+          expect(new_service_offering).to be_valid
+        end
+      end
+
+      context 'when the service_code is different' do
+        let(:service_code) { '1.2' }
+
+        it 'is valid' do
+          expect(new_service_offering).to be_valid
+        end
+      end
+
+      context 'when the jurisdiction is different' do
+        let(:jurisdiction) { 'b' }
+
+        it 'is valid' do
+          expect(new_service_offering).to be_valid
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/NestedGroups
+
+  describe '.supplier_ids_for_service_codes_and_jurisdiction' do
+    let(:result) { described_class.supplier_ids_for_service_codes_and_jurisdiction(service_codes, jurisdiction) }
+    let(:supplier1) { create(:legal_services_rm6240_supplier) }
+    let(:supplier2) { create(:legal_services_rm6240_supplier) }
+    let(:supplier1_id) { supplier1.id }
+    let(:supplier2_id) { supplier2.id }
+    let(:jurisdiction) { 'a' }
+
+    before do
+      create(:legal_services_rm6240_full_service_provision_service_offering, supplier: supplier1)
+      create(:legal_services_rm6240_full_service_provision_service_offering, supplier: supplier2)
+      create(:legal_services_rm6240_full_service_provision_service_offering, supplier: supplier1, service_code: '1.2', jurisdiction: 'b')
+      create(:legal_services_rm6240_full_service_provision_service_offering, supplier: supplier2, service_code: '1.2')
+      create(:legal_services_rm6240_transport_rail_service_offering, supplier: supplier2)
+    end
+
+    context 'when we pass a single service code' do
+      let(:service_codes) { ['1.1'] }
+
+      it 'returns both suppliers' do
+        expect(result).to match_array([supplier1_id, supplier2_id])
+      end
+    end
+
+    context 'when we pass multiple service codes' do
+      let(:service_codes) { ['1.1', '1.2'] }
+
+      it 'returns both suppliers once each' do
+        expect(result).to match_array([supplier1_id, supplier2_id])
+      end
+    end
+
+    context 'when we pass service codes neither supplier does' do
+      let(:service_codes) { ['2.1'] }
+
+      it 'returns an emoty array' do
+        expect(result).to be_empty
+      end
+    end
+
+    context 'when we pass 3.1 for the service' do
+      let(:service_codes) { ['3.1'] }
+      let(:jurisdiction) { nil }
+
+      it 'returns the second supplier' do
+        expect(result).to match_array([supplier2_id])
+      end
+    end
+
+    context 'when we pass a different jurisdiction' do
+      let(:service_codes) { ['1.2'] }
+      let(:jurisdiction) { 'b' }
+
+      it 'returns the first supplier' do
+        expect(result).to match_array([supplier1_id])
+      end
+    end
+  end
+end

--- a/spec/models/legal_services/rm6240/service_spec.rb
+++ b/spec/models/legal_services/rm6240/service_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe LegalServices::RM6240::Service, type: :model do
+  subject(:services) { described_class.all }
+
+  let(:available_to_central_government) { described_class.where(central_government: true) }
+  let(:first_service) { services.first }
+  let(:all_service_code) { described_class.all_service_code }
+
+  it 'loads services from CSV' do
+    expect(services.count).to eq(56)
+  end
+
+  it 'populates attributes of first service' do
+    expect(first_service.attributes).to eq(
+      {
+        lot_number: '1',
+        service_number: '1',
+        name: 'Administrative and Public Law',
+        central_government: true
+      }
+    )
+  end
+
+  it 'only has unique codes' do
+    expect(all_service_code.uniq).to contain_exactly(*all_service_code)
+  end
+
+  it 'all have names' do
+    expect(services.select { |s| s.name.blank? }).to be_empty
+  end
+
+  it 'all to say if they are available to central government' do
+    expect(services.select { |s| s.central_government.nil? }).to be_empty
+  end
+
+  it 'to only have some services available to central government buyers' do
+    expect(available_to_central_government.count).to eq(5)
+  end
+
+  describe '.all_service_code' do
+    it 'returns codes for all services' do
+      expect(all_service_code.count).to eq(services.count)
+      expect(all_service_code.first).to eq(first_service.service_code)
+    end
+  end
+
+  describe '.services_for_lot' do
+    context 'when selecting from lots 1, 2 or 3' do
+      ['1', '2', '3'].each do |lot_number|
+        it 'returns the correct services for that lot' do
+          selected_lot_services = described_class.where(lot_number: lot_number)
+
+          expect(described_class.services_for_lot(lot_number)).to eq(selected_lot_services)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/legal_services/rm6240/supplier_spec.rb
+++ b/spec/models/legal_services/rm6240/supplier_spec.rb
@@ -1,0 +1,137 @@
+require 'rails_helper'
+
+RSpec.describe LegalServices::RM6240::Supplier, type: :model do
+  subject(:supplier) { build(:legal_services_rm6240_supplier) }
+
+  describe 'validations' do
+    before { supplier.name = supplier_name }
+
+    context 'when the supplier name is blank' do
+      let(:supplier_name) { '' }
+
+      it 'is not valid' do
+        expect(supplier).not_to be_valid
+      end
+    end
+
+    context 'when the supplier name is present' do
+      let(:supplier_name) { supplier.name }
+
+      it 'is valid' do
+        expect(supplier).to be_valid
+      end
+    end
+  end
+
+  context 'when destroying the supplier' do
+    before { supplier.save! }
+
+    context 'and the supplier has service offerings' do
+      let!(:service_offering) { create(:legal_services_rm6240_full_service_provision_service_offering, supplier: supplier) }
+
+      it 'destroys all its service offerings' do
+        supplier.destroy!
+
+        expect(LegalServices::RM6240::ServiceOffering.exists?(service_offering.id)).to be false
+      end
+    end
+
+    context 'and the supplier has rates' do
+      let!(:rate) { create(:legal_services_rm6240_full_service_provision_rate, supplier: supplier) }
+
+      it 'destroys all its rates' do
+        supplier.destroy!
+
+        expect(LegalServices::RM6240::Rate.exists?(rate.id)).to be false
+      end
+    end
+  end
+
+  describe '#set_service_codes' do
+    let(:result) { described_class.set_service_codes(lot_number, %w[1 13 30 50]) }
+
+    context 'when the lot is 1' do
+      let(:lot_number) { '1' }
+
+      it 'only returns the the service codes for service numbers that exist in the lot' do
+        expect(result).to eq(%w[1.1 1.13 1.30])
+      end
+    end
+
+    context 'when the lot is 2' do
+      let(:lot_number) { '2' }
+
+      it 'only returns the the service codes for service numbers that exist in the lot' do
+        expect(result).to eq(%w[2.1 2.13])
+      end
+    end
+
+    context 'when the lot is 3' do
+      let(:lot_number) { '3' }
+
+      it 'only returns the the service codes for service numbers that exist in the lot' do
+        expect(result).to eq(%w[3.1])
+      end
+    end
+  end
+
+  describe '#offering_services_in_jurisdiction' do
+    let(:result) { described_class.offering_services_in_jurisdiction(lot_number, service_numbers, jurisdiction) }
+    let(:supplier1) { create(:legal_services_rm6240_supplier) }
+    let(:supplier2) { create(:legal_services_rm6240_supplier) }
+    let(:lot_number) { '1' }
+    let(:jurisdiction) { 'a' }
+
+    before do
+      create(:legal_services_rm6240_full_service_provision_service_offering, supplier: supplier1)
+      create(:legal_services_rm6240_full_service_provision_service_offering, supplier: supplier2)
+      create(:legal_services_rm6240_full_service_provision_service_offering, supplier: supplier1, service_code: '1.2', jurisdiction: 'b')
+      create(:legal_services_rm6240_full_service_provision_service_offering, supplier: supplier2, service_code: '1.2')
+      create(:legal_services_rm6240_transport_rail_service_offering, supplier: supplier2)
+    end
+
+    context 'when we pass a single service number' do
+      let(:service_numbers) { %w[1] }
+
+      it 'returns both suppliers' do
+        expect(result).to match_array([supplier1, supplier2])
+      end
+    end
+
+    context 'when we pass multiple service numbers' do
+      let(:service_numbers) { %w[1 2] }
+
+      it 'returns both suppliers once each' do
+        expect(result).to match_array([supplier1, supplier2])
+      end
+    end
+
+    context 'when we pass service numbers neither supplier does' do
+      let(:lot_number) { '2' }
+      let(:service_numbers) { %w[1] }
+
+      it 'returns an emoty array' do
+        expect(result).to be_empty
+      end
+    end
+
+    context 'when we pass 3 for the lot number and 1 for the service number' do
+      let(:lot_number) { '3' }
+      let(:service_numbers) { %w[1] }
+      let(:jurisdiction) { nil }
+
+      it 'returns the second supplier' do
+        expect(result).to match_array([supplier2])
+      end
+    end
+
+    context 'when we pass a different jurisdiction' do
+      let(:service_numbers) { %w[2] }
+      let(:jurisdiction) { 'b' }
+
+      it 'returns the first supplier' do
+        expect(result).to match_array([supplier1])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [FMR-1209](https://crowncommercialservice.atlassian.net/browse/FMFR-1209)

We are creating a new framework for legal services. In this commit I have created the models in the database for the new legal service framework. There are some changes from the previous framework, most notebally:

- Using a single service offerings model to determine of the supplier can offer the service in the jurisdiction
- Storing the rates as an integer to avoid issues with floats

Though we don’t have an upload yet, I have created/copied specs based on the previous framework to make sure it is all working.