### PR TITLE
FMFR-1271 - Allow special access to change framework dates

### DIFF
--- a/app/controllers/legal_services/admin/frameworks_controller.rb
+++ b/app/controllers/legal_services/admin/frameworks_controller.rb
@@ -13,7 +13,7 @@ module LegalServices
       private
 
       def authorize_user
-        authorize! :manage, LegalServices::RM3788::Admin::Upload
+        authorize! :manage, Framework
       end
     end
   end

--- a/app/controllers/management_consultancy/admin/frameworks_controller.rb
+++ b/app/controllers/management_consultancy/admin/frameworks_controller.rb
@@ -13,7 +13,7 @@ module ManagementConsultancy
       private
 
       def authorize_user
-        authorize! :manage, ManagementConsultancy::RM6187::Admin::Upload
+        authorize! :manage, Framework
       end
     end
   end

--- a/app/controllers/supply_teachers/admin/frameworks_controller.rb
+++ b/app/controllers/supply_teachers/admin/frameworks_controller.rb
@@ -9,6 +9,12 @@ module SupplyTeachers
       def framework_index_path
         supply_teachers_admin_frameworks_path
       end
+
+      private
+
+      def authorize_user
+        authorize! :manage, Framework
+      end
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -31,8 +31,10 @@ class Ability
       can :manage, LegalServices::RM3788::Admin::Upload
     end
 
-    return unless user.has_role? :st_access
+    can :manage, SupplyTeachers::Admin if user.has_role? :st_access
 
-    can :manage, SupplyTeachers::Admin
+    return unless user.has_role? :ccs_developer
+
+    can :manage, Framework
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
 
   # declare the valid roles -- do not change the order if you add more
   # roles later, always append them at the end!
-  roles :buyer, :supplier, :ccs_employee, :ccs_admin, :st_access, :ls_access, :mc_access
+  roles :buyer, :supplier, :ccs_employee, :ccs_admin, :st_access, :ls_access, :mc_access, :ccs_developer
 
   attr_accessor :password, :password_confirmation
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -168,8 +168,4 @@ module Marketplace
   def self.rails_env_url
     @rails_env_url ||= ENV.fetch('RAILS_ENV_URL', 'https://marketplace.service.crowncommercial.gov.uk')
   end
-
-  def self.can_edit_legacy_frameworks?
-    @can_edit_legacy_frameworks ||= rails_env_url != 'https://marketplace.service.crowncommercial.gov.uk'
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,7 +90,7 @@ Rails.application.routes.draw do
   end
 
   concern :admin_frameworks do
-    resources :frameworks, only: %i[index edit update] if Marketplace.can_edit_legacy_frameworks?
+    resources :frameworks, only: %i[index edit update]
   end
 
   concern :admin_uploads do

--- a/spec/controllers/legal_services/admin/frameworks_controller_spec.rb
+++ b/spec/controllers/legal_services/admin/frameworks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe LegalServices::Admin::FrameworksController do
   let(:default_params) { { service: 'legal_services/admin' } }
 
-  login_ls_admin
+  login_ccs_developer
 
   describe 'GET index' do
     it 'renders the index page' do
@@ -13,6 +13,15 @@ RSpec.describe LegalServices::Admin::FrameworksController do
 
     context 'when logged in as a buyer' do
       login_ls_buyer
+
+      it 'redirects to not permitted' do
+        get :index
+        expect(response).to redirect_to '/legal-services/RM6240/admin/not-permitted'
+      end
+    end
+
+    context 'when logged in as a normal admin' do
+      login_ls_admin
 
       it 'redirects to not permitted' do
         get :index

--- a/spec/controllers/management_consultancy/admin/frameworks_controller_spec.rb
+++ b/spec/controllers/management_consultancy/admin/frameworks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ManagementConsultancy::Admin::FrameworksController do
   let(:default_params) { { service: 'management_consultancy/admin' } }
 
-  login_mc_admin
+  login_ccs_developer
 
   describe 'GET index' do
     it 'renders the index page' do
@@ -13,6 +13,15 @@ RSpec.describe ManagementConsultancy::Admin::FrameworksController do
 
     context 'when logged in as a buyer' do
       login_mc_buyer
+
+      it 'redirects to not permitted' do
+        get :index
+        expect(response).to redirect_to '/management-consultancy/RM6187/admin/not-permitted'
+      end
+    end
+
+    context 'when logged in as a normal admin' do
+      login_mc_admin
 
       it 'redirects to not permitted' do
         get :index

--- a/spec/controllers/supply_teachers/admin/frameworks_controller_spec.rb
+++ b/spec/controllers/supply_teachers/admin/frameworks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupplyTeachers::Admin::FrameworksController do
   let(:default_params) { { service: 'supply_teachers/admin' } }
 
-  login_st_admin
+  login_ccs_developer
 
   describe 'GET index' do
     it 'renders the index page' do
@@ -13,6 +13,15 @@ RSpec.describe SupplyTeachers::Admin::FrameworksController do
 
     context 'when logged in as a buyer' do
       login_st_buyer
+
+      it 'redirects to not permitted' do
+        get :index
+        expect(response).to redirect_to '/supply-teachers/RM6238/admin/not-permitted'
+      end
+    end
+
+    context 'when logged in as a normal admin' do
+      login_st_admin
 
       it 'redirects to not permitted' do
         get :index

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -70,4 +70,12 @@ module ControllerMacros
       sign_in user
     end
   end
+
+  def login_ccs_developer
+    before do
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      user = FactoryBot.create(:user, confirmed_at: Time.zone.now, roles: %i[ccs_employee ccs_developer])
+      sign_in user
+    end
+  end
 end


### PR DESCRIPTION
Ticket: [FMR-1271](https://crowncommercialservice.atlassian.net/browse/FMFR-1271)

To make it easier to change the framework dates in production, i.e. without the need for a deployment, I have added the new role `ccs_developer` which gives limited access to change the framework dates.