### PR TITLE
FMFR-1214 add suitability question for new framework

### DIFF
--- a/app/models/legal_services/journey/check_suitability.rb
+++ b/app/models/legal_services/journey/check_suitability.rb
@@ -1,0 +1,11 @@
+module LegalServices
+  class Journey::CheckSuitability
+    include Steppable
+
+    SUITABILITY_OPTIONS = %w[yes no].freeze
+
+    attribute :service_suitable
+    attribute :lot
+    validates :service_suitable, inclusion: ['yes', 'no']
+  end
+end

--- a/app/models/legal_services/journey/select_lot.rb
+++ b/app/models/legal_services/journey/select_lot.rb
@@ -4,9 +4,5 @@ module LegalServices
 
     attribute :lot
     validates :lot, presence: true
-
-    def self.lots
-      module_parent.module_parent::Lot.all.sort_by(&:number)
-    end
   end
 end

--- a/app/models/legal_services/rm3788/journey/select_lot.rb
+++ b/app/models/legal_services/rm3788/journey/select_lot.rb
@@ -1,6 +1,10 @@
 module LegalServices
   module RM3788
     class Journey::SelectLot < LegalServices::Journey::SelectLot
+      def self.lots(_central_government)
+        Lot.all.sort_by(&:number)
+      end
+
       def next_step_class
         case lot
         when '1'

--- a/app/models/legal_services/rm6240/journey/check_suitability.rb
+++ b/app/models/legal_services/rm6240/journey/check_suitability.rb
@@ -1,10 +1,10 @@
 module LegalServices
-  module RM3788
+  module RM6240
     class Journey::CheckSuitability < LegalServices::Journey::CheckSuitability
       def next_step_class
         case service_suitable
         when 'yes'
-          Journey::ChooseServices
+          Journey::SelectLot
         when 'no'
           Journey::Sorry
         end

--- a/app/models/legal_services/rm6240/journey/select_lot.rb
+++ b/app/models/legal_services/rm6240/journey/select_lot.rb
@@ -1,6 +1,14 @@
 module LegalServices
   module RM6240
     class Journey::SelectLot < LegalServices::Journey::SelectLot
+      def self.lots(central_government)
+        if central_government == 'yes'
+          Lot.all_central_government
+        else
+          Lot.all
+        end.sort_by(&:number)
+      end
+
       def next_step_class
         case lot
         when '1', '2'

--- a/app/models/legal_services/rm6240/lot.rb
+++ b/app/models/legal_services/rm6240/lot.rb
@@ -12,6 +12,10 @@ module LegalServices
       def self.all_numbers
         all.map(&:number)
       end
+
+      def self.all_central_government
+        where(number: %w[1 2])
+      end
     end
 
     Lot.load_csv('legal_services/rm6240/lots.csv')

--- a/app/views/legal_services/journey/_select_lot.html.erb
+++ b/app/views/legal_services/journey/_select_lot.html.erb
@@ -14,7 +14,7 @@
             page_heading?: true
           }
         },
-        items: @journey.current_step.class.lots.map do |lot|
+        items: @journey.current_step.class.lots(@journey.params['central_government']).map do |lot|
           {
             value: lot.number,
             checked: checked?(params[:lot], lot.number),

--- a/app/views/legal_services/rm6240/journey/check_suitability.html.erb
+++ b/app/views/legal_services/rm6240/journey/check_suitability.html.erb
@@ -1,0 +1,38 @@
+<%= add_optional_error_prefix_to_page_title(@journey.errors) %>
+<%= content_for :page_title, t('.heading') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'shared/error_summary', locals: { errors: @journey.errors } %>
+    <h1 class="govuk-heading-m">
+      <%= t('.heading') %>
+    </h1>
+
+    <p><%= t('.advice') %></p>
+
+    <%= form_with url: @form_path, method: :get, local: true, html: { specialvalidation: true, novalidate: true } do |f| %>
+      <%= hidden_fields_for_previous_steps_and_responses(@journey) %>
+
+      <%= govuk_radios(f, @journey, :service_suitable, {
+        fieldset: {
+          legend: {
+            text: t('.question'),
+            page_heading?: false
+          }
+        },
+        classes: 'govuk-radios--inline',
+        items: @journey.current_step.class::SUITABILITY_OPTIONS.map do |option|
+          {
+            value: option,
+            checked: checked?(params[:service_suitable], option),
+            label: {
+              text: t(option)
+            }
+          }
+        end
+      }) %>
+
+      <%= submit_tag t('common.submit'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", name: t('common.submit') %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/views/legal_services.en.yml
+++ b/config/locales/views/legal_services.en.yml
@@ -28,6 +28,10 @@ en:
           attributes:
             lot:
               blank: Select the lot you need
+        legal_services/rm6240/journey/check_suitability:
+          attributes:
+            service_suitable:
+              inclusion: Select yes if your requirements allow you to continue
         legal_services/rm6240/journey/choose_jurisdiction:
           attributes:
             jurisdiction:
@@ -451,3 +455,8 @@ en:
             para05_html: To use this service you need to be a recognised public sector body listed in the <a href="https://assets.crowncommercial.gov.uk/wp-content/uploads/RM6240-Contract-Notice-Authorised-Customer-List.docx">authorised customer list</a>.
           wps_link_text: WPS Legal Services panel specification
           wps_url: https://www.crowncommercial.gov.uk/agreements/RM6240
+      journey:
+        check_suitability:
+          advice: INFORMATION TO MAKE THE DECISION
+          heading: Is this service suitable for your requirements?
+          question: Do your requirements allow you to continue to select lot?

--- a/spec/models/legal_services/rm3788/journey/select_lot_spec.rb
+++ b/spec/models/legal_services/rm3788/journey/select_lot_spec.rb
@@ -85,4 +85,24 @@ RSpec.describe LegalServices::RM3788::Journey::SelectLot, type: :model do
       expect(step.final?).to be false
     end
   end
+
+  describe '.lots' do
+    let(:result) { described_class.lots(central_government) }
+
+    context 'when central government is yes' do
+      let(:central_government) { 'yes' }
+
+      it 'returns the 4 lots sorted' do
+        expect(result.map(&:number)).to eq %w[1 2 3 4]
+      end
+    end
+
+    context 'when central government is no' do
+      let(:central_government) { 'no' }
+
+      it 'returns the 4 lots sorted' do
+        expect(result.map(&:number)).to eq %w[1 2 3 4]
+      end
+    end
+  end
 end

--- a/spec/models/legal_services/rm6240/journey/check_suitability_spec.rb
+++ b/spec/models/legal_services/rm6240/journey/check_suitability_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe LegalServices::RM6240::Journey::CheckSuitability, type: :model do
+  subject(:step) { described_class.new(service_suitable: service_suitable) }
+
+  let(:service_suitable) { 'yes' }
+
+  describe 'validations' do
+    context 'when no service_suitable is provided' do
+      let(:service_suitable) { '' }
+
+      it 'is not valid and has the correct error message' do
+        expect(step).not_to be_valid
+        expect(step.errors[:service_suitable].first).to eq 'Select yes if your requirements allow you to continue'
+      end
+    end
+
+    context 'when service_suitable is not in the list' do
+      let(:service_suitable) { 'non-valid-option' }
+
+      it 'is not valid and has the correct error message' do
+        expect(step).not_to be_valid
+        expect(step.errors[:service_suitable].first).to eq 'Select yes if your requirements allow you to continue'
+      end
+    end
+
+    context 'when an option that is in the list provided' do
+      it 'is valid' do
+        expect(step).to be_valid
+      end
+    end
+  end
+
+  describe '.next_step_class' do
+    context 'and the service_suitable is yes' do
+      let(:service_suitable) { 'yes' }
+
+      it 'returns Journey::SelectLot' do
+        expect(step.next_step_class).to be LegalServices::RM6240::Journey::SelectLot
+      end
+    end
+
+    context 'and the service_suitable is no' do
+      let(:service_suitable) { 'no' }
+
+      pending 'returns Journey::Sorry' do
+        expect(step.next_step_class).to be LegalServices::RM6240::Journey::Sorry
+      end
+    end
+  end
+
+  describe '.permit_list' do
+    it 'returns a list of the permitted attributes' do
+      expect(described_class.permit_list).to eq [:service_suitable, :lot, {}]
+    end
+  end
+
+  describe '.permitted_keys' do
+    it 'returns a list of the permitted keys' do
+      expect(described_class.permitted_keys).to eq %i[service_suitable lot]
+    end
+  end
+
+  describe '.slug' do
+    it 'returns check-suitability' do
+      expect(step.slug).to eq 'check-suitability'
+    end
+  end
+
+  describe '.template' do
+    it 'returns journey/check_suitability' do
+      expect(step.template).to eq 'journey/check_suitability'
+    end
+  end
+
+  describe '.final?' do
+    it 'returns false' do
+      expect(step.final?).to be false
+    end
+  end
+end

--- a/spec/models/legal_services/rm6240/journey/choose_organisation_type_spec.rb
+++ b/spec/models/legal_services/rm6240/journey/choose_organisation_type_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe LegalServices::RM6240::Journey::ChooseOrganisationType, type: :mo
     context 'and the central government is yes' do
       let(:central_government) { 'yes' }
 
-      pending 'returns Journey::CheckSuitability' do
+      it 'returns Journey::CheckSuitability' do
         expect(step.next_step_class).to be LegalServices::RM6240::Journey::CheckSuitability
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe LegalServices::RM6240::Journey::ChooseOrganisationType, type: :mo
   end
 
   describe '.final?' do
-    pending 'returns false' do
+    it 'returns false' do
       expect(step.final?).to be false
     end
   end

--- a/spec/models/legal_services/rm6240/journey/select_lot_spec.rb
+++ b/spec/models/legal_services/rm6240/journey/select_lot_spec.rb
@@ -77,4 +77,24 @@ RSpec.describe LegalServices::RM6240::Journey::SelectLot, type: :model do
       expect(step.final?).to be false
     end
   end
+
+  describe '.lots' do
+    let(:result) { described_class.lots(central_government) }
+
+    context 'when central government is yes' do
+      let(:central_government) { 'yes' }
+
+      it 'returns the 2 lots sorted' do
+        expect(result.map(&:number)).to eq %w[1 2]
+      end
+    end
+
+    context 'when central government is no' do
+      let(:central_government) { 'no' }
+
+      it 'returns the 3 lots sorted' do
+        expect(result.map(&:number)).to eq %w[1 2 3]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Tickets:
- [FMFR-1214](https://crowncommercialservice.atlassian.net/browse/FMFR-1214)
- [FMFR-1216](https://crowncommercialservice.atlassian.net/browse/FMFR-1215)

I have added the suitability option for when the buyer belongs to Central Government. I’ve also made an update to carry through the ‘Central government’ option so only the relevant lots and services are shown on later pages.