### PR TITLE
This fixes some issues with these tests which were failing on certain dates.

### DIFF
--- a/features/services/supply_teachers/rm3826/journey/agency_results/fixed_term/daily_rate.feature
+++ b/features/services/supply_teachers/rm3826/journey/agency_results/fixed_term/daily_rate.feature
@@ -15,7 +15,7 @@ Feature: Supply Teachers - Agency results - Fixed term - Daily rate
     And I enter 'tomorrow' for the date
     And I click on 'Continue'
     Then I am on the 'What date do you want the employee to stop working?' page
-    And I enter a date 0 years and 3 months into the future
+    And I enter a date 2 and a half months into the future
     And I click on 'Continue'
     Then I am on the "What would the employee's annual salary be?" page
     And I enter '28000' for the 'salary'

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/daily_rate.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/daily_rate.feature
@@ -15,7 +15,7 @@ Feature: Supply Teachers - Agency results - Fixed term - Daily rate
     And I enter 'tomorrow' for the date
     And I click on 'Continue'
     Then I am on the 'What date do you want the employee to stop working?' page
-    And I enter a date 0 years and 3 months into the future
+    And I enter a date 2 and a half months into the future
     And I click on 'Continue'
     Then I am on the "What would the employee's annual salary be?" page
     And I enter '28000' for the 'salary'

--- a/features/step_definitions/supply_teachers_steps.rb
+++ b/features/step_definitions/supply_teachers_steps.rb
@@ -16,6 +16,12 @@ Then('I enter a date {int} years and {int} months into the future') do |years, m
   add_dates(:date_field, *date.strftime('%d/%m/%Y').split('/'))
 end
 
+Then('I enter a date {int} and a half months into the future') do |months|
+  date = Time.zone.today + months.months + 20.days
+
+  add_dates(:date_field, *date.strftime('%d/%m/%Y').split('/'))
+end
+
 Then('I enter a date {int} years and {int} months into the past') do |years, months|
   date = Time.zone.today - years.years - months.months
 


### PR DESCRIPTION
This fixes some issues with these tests which were failing on certain dates.

This is because on most dates the length of the contract used in this test would be 2.5 months. However, on some days (including today 30 August 20220, it would be calculated (correctly) as 3 months.

This change will make sure that the length is always 2.5 months on every day of the year.