### PR TITLE
FMFR-1288 - Make sure the rates are sorted correctly by job role

### DIFF
--- a/app/controllers/supply_teachers/suppliers_controller.rb
+++ b/app/controllers/supply_teachers/suppliers_controller.rb
@@ -5,7 +5,7 @@ module SupplyTeachers
     helper :telephone_number
 
     def all_suppliers
-      @back_path = source_journey.previous_step_path
+      @back_path = "/supply-teachers/#{params[:framework]}/looking-for?looking_for=all_suppliers"
       @suppliers_count = service_name::Branch.distinct_suppliers_count
     end
 

--- a/app/helpers/supply_teachers/rm6238/shared_helper.rb
+++ b/app/helpers/supply_teachers/rm6238/shared_helper.rb
@@ -1,4 +1,10 @@
 module SupplyTeachers::RM6238::SharedHelper
+  def grouped_rates_sorted_by_job_type(grouped_rates)
+    job_types = SupplyTeachers::RM6238::JobType.all_codes
+
+    grouped_rates.sort_by { |job_type, _| job_types.index(job_type) }
+  end
+
   def agency_rate_cell(rate)
     rate_value = if rate.percentage?
                    number_to_percentage(rate.value, precision: 1)

--- a/app/models/supply_teachers/rm6238/rate.rb
+++ b/app/models/supply_teachers/rm6238/rate.rb
@@ -51,7 +51,7 @@ module SupplyTeachers
       end
 
       def percentage?
-        (job_type == 'over_12_week' || job_type == 'fixed_term') && term != 'six_weeks_plus'
+        job_type == 'over_12_week' || job_type == 'fixed_term'
       end
 
       def term_required?

--- a/app/services/supply_teachers/rm6238/admin/data_import/generate_pricing.rb
+++ b/app/services/supply_teachers/rm6238/admin/data_import/generate_pricing.rb
@@ -36,7 +36,7 @@ module SupplyTeachers
 
         def normalize_pricing(row)
           case row[:job_type]
-          when :nominated, :fixed_term
+          when :nominated, :fixed_term, :over_12_week
             row.merge(fee: row[:fee1])
           when :agency_management_daily
             row.merge(term: :daily, fee: row[:fee1])
@@ -65,7 +65,7 @@ module SupplyTeachers
         end
 
         def percentage?(row)
-          row[:job_type] == :fixed_term || (row[:job_type] == :over_12_week && row[:term] == :daily)
+          row[:job_type] == :fixed_term || row[:job_type] == :over_12_week
         end
       end
     end

--- a/app/views/supply_teachers/rm6238/shared/_rates_table.html.erb
+++ b/app/views/supply_teachers/rm6238/shared/_rates_table.html.erb
@@ -7,7 +7,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% grouped_rates.each do |job_type, rates| %>
+    <% grouped_rates_sorted_by_job_type(grouped_rates).each do |job_type, rates| %>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row"><%= SupplyTeachers::RM6238::JobType[job_type] %></th>
         <% if rates.length == 1 %>

--- a/data/supply_teachers/rm6238/dummy_supplier_data.json
+++ b/data/supply_teachers/rm6238/dummy_supplier_data.json
@@ -57,14 +57,8 @@
       {
         "lot_number": "2.1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 0
-      },
-      {
-        "lot_number": "2.1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 21728
       },
       {
         "lot_number": "2.1",
@@ -145,14 +139,8 @@
       {
         "lot_number": "2.1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 0
-      },
-      {
-        "lot_number": "2.1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 11296
       },
       {
         "lot_number": "2.1",
@@ -217,14 +205,8 @@
       {
         "lot_number": "2.2",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 800
-      },
-      {
-        "lot_number": "2.2",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 20756
       },
       {
         "lot_number": "2.2",
@@ -305,14 +287,8 @@
       {
         "lot_number": "2.1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 0
-      },
-      {
-        "lot_number": "2.1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 12120
       },
       {
         "lot_number": "2.1",
@@ -377,14 +353,8 @@
       {
         "lot_number": "2.2",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 600
-      },
-      {
-        "lot_number": "2.2",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 22864
       },
       {
         "lot_number": "2.2",
@@ -465,14 +435,8 @@
       {
         "lot_number": "2.2",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 1000
-      },
-      {
-        "lot_number": "2.2",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 22552
       },
       {
         "lot_number": "2.2",
@@ -588,14 +552,8 @@
       {
         "lot_number": "1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 100
-      },
-      {
-        "lot_number": "1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 15936
       },
       {
         "lot_number": "1",
@@ -708,14 +666,8 @@
       {
         "lot_number": "1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 100
-      },
-      {
-        "lot_number": "1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 11036
       },
       {
         "lot_number": "1",
@@ -828,14 +780,8 @@
       {
         "lot_number": "1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 1000
-      },
-      {
-        "lot_number": "1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 23820
       },
       {
         "lot_number": "1",
@@ -948,14 +894,8 @@
       {
         "lot_number": "1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 300
-      },
-      {
-        "lot_number": "1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 23340
       },
       {
         "lot_number": "1",
@@ -1068,14 +1008,8 @@
       {
         "lot_number": "1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 600
-      },
-      {
-        "lot_number": "1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 19176
       },
       {
         "lot_number": "1",
@@ -1152,14 +1086,8 @@
       {
         "lot_number": "1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 100
-      },
-      {
-        "lot_number": "1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 19992
       },
       {
         "lot_number": "1",
@@ -1236,14 +1164,8 @@
       {
         "lot_number": "1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 600
-      },
-      {
-        "lot_number": "1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 17064
       },
       {
         "lot_number": "1",
@@ -1332,14 +1254,8 @@
       {
         "lot_number": "1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 200
-      },
-      {
-        "lot_number": "1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 21428
       },
       {
         "lot_number": "1",
@@ -1416,14 +1332,8 @@
       {
         "lot_number": "1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 100
-      },
-      {
-        "lot_number": "1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 16580
       },
       {
         "lot_number": "1",
@@ -1524,14 +1434,8 @@
       {
         "lot_number": "1",
         "job_type": "over_12_week",
-        "term": "daily",
+        "term": null,
         "fee": 500
-      },
-      {
-        "lot_number": "1",
-        "job_type": "over_12_week",
-        "term": "six_weeks_plus",
-        "fee": 15792
       },
       {
         "lot_number": "1",

--- a/data/supply_teachers/rm6238/job_types.csv
+++ b/data/supply_teachers/rm6238/job_types.csv
@@ -3,7 +3,7 @@
 "support","Educational Support Staff: (incl. Cover Supervisor, Teaching Assistants)","true","true"
 "senior","Senior Roles: Headteacher and Senior Leadership positions","true","true"
 "other","Other Roles: (Invigilators, Admin & Clerical, IT Staff, Finance Staff, Cleaners etc.)","true","true"
-"over_12_week","Over 12 Week Reduction","false","true"
+"over_12_week","Over 12 Week Reduction","false","false"
 "nominated","Nominated Worker","false","false"
 "fixed_term","Fixed Term","false","false"
 "agency_management","Agency Management","false","true"

--- a/features/services/supply_teachers/rm6238/jounrey/all_agencies/suppliers.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/all_agencies/suppliers.feature
@@ -33,7 +33,7 @@ Feature: Supply Teachers - All agencies - suppliers
       | Educational Support Staff: (incl. Cover Supervisor, Teaching Assistants)              | £52.51  | £49.88  |
       | Senior Roles: Headteacher and Senior Leadership positions                             | £64.18  | £60.97  |
       | Other Roles: (Invigilators, Admin & Clerical, IT Staff, Finance Staff, Cleaners etc.) | £55.43  | £52.65  |
-      | Over 12 Week Reduction                                                                | 3.0%    | £233.40 |
+      | Over 12 Week Reduction                                                                | 3.0%    | 3.0%    |
       | Nominated Worker                                                                      | £46.68  | £46.68  |
       | Fixed Term                                                                            | 35.0%   | 35.0%   |
     And the 'Branch' is 'Liverpool - Merseyside' for the 'Liverpool' branch

--- a/features/services/supply_teachers/rm6238/jounrey/master_vendor/master_vendor_above_threshold.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/master_vendor/master_vendor_above_threshold.feature
@@ -21,7 +21,7 @@ Feature: Supply Teachers - Master vendors - Above threshold
       | bogan.and.collier.reichert@murray.net |
     And the master vendor agency 'BOGAN, REICHERT AND COLLIER' has the following rates:
       | Teacher: (Incl. Qualified and Unqualified Teachers, Tutors) | £57.16  | £54.30  |
-      | Over 12 Week Reduction                                      | 6.0%    | £228.64 |
+      | Over 12 Week Reduction                                      | 6.0%    | 6.0%    |
       | Fixed Term                                                  | 34.3%   | 34.3%   |
     And I click on 'Back'
     Then I am on the 'Is your contract likely to be worth more than £2.5 million?' page

--- a/features/services/supply_teachers/rm6238/jounrey/master_vendor/master_vendor_below_threshold.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/master_vendor/master_vendor_below_threshold.feature
@@ -21,7 +21,7 @@ Feature: Supply Teachers - Master vendors - Below threshold
       | luettgen.gutmann@wintheiser-breitenberg.name  |
     And the master vendor agency 'LUETTGEN-GUTMANN' has the following rates:
       | Teacher: (Incl. Qualified and Unqualified Teachers, Tutors) | £54.32  | £51.60  |
-      | Over 12 Week Reduction                                      | 0.0%	  | £217.28 |
+      | Over 12 Week Reduction                                      | 0.0%    | 0.0%    |
       | Fixed Term                                                  | 32.6%   | 32.6%   |
     And I click on 'Back'
     Then I am on the 'Is your contract likely to be worth more than £2.5 million?' page

--- a/spec/helpers/supply_teachers/rm6238/shared_helper_spec.rb
+++ b/spec/helpers/supply_teachers/rm6238/shared_helper_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe SupplyTeachers::RM6238::SharedHelper, type: :helper do
+  let(:supplier) { create(:supply_teachers_rm6238_supplier) }
+  let(:rate_teacher_1) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'teacher', term: 'daily') }
+  let(:rate_teacher_2) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'teacher', term: 'six_weeks_plus') }
+  let(:rate_support_1) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'support', term: 'daily') }
+  let(:rate_support_2) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'support', term: 'six_weeks_plus') }
+  let(:rate_senior_1) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'senior', term: 'daily') }
+  let(:rate_senior_2) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'senior', term: 'six_weeks_plus') }
+  let(:rate_other_1) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'other', term: 'daily') }
+  let(:rate_other_2) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'other', term: 'six_weeks_plus') }
+  let(:rate_over_12_week) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'over_12_week') }
+  let(:rate_nominated) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'nominated') }
+  let(:rate_fixed_term) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'fixed_term') }
+
+  describe '.grouped_rates_sorted_by_job_type' do
+    let(:unsorted_grouped_rates) do
+      [
+        [
+          'support',
+          [rate_support_1, rate_support_2]
+        ],
+        [
+          'fixed_term',
+          [rate_fixed_term]
+        ],
+        [
+          'senior',
+          [rate_senior_1, rate_senior_2]
+        ],
+        [
+          'nominated',
+          [rate_nominated]
+        ],
+        [
+          'other',
+          [rate_other_1, rate_other_2]
+        ],
+        [
+          'over_12_week',
+          [rate_over_12_week]
+        ],
+        [
+          'teacher',
+          [rate_teacher_1, rate_teacher_2]
+        ]
+      ]
+    end
+
+    let(:sorted_grouped_rates) do
+      [
+        [
+          'teacher',
+          [rate_teacher_1, rate_teacher_2]
+        ],
+        [
+          'support',
+          [rate_support_1, rate_support_2]
+        ],
+        [
+          'senior',
+          [rate_senior_1, rate_senior_2]
+        ],
+        [
+          'other',
+          [rate_other_1, rate_other_2]
+        ],
+        [
+          'over_12_week',
+          [rate_over_12_week]
+        ],
+        [
+          'nominated',
+          [rate_nominated]
+        ],
+        [
+          'fixed_term',
+          [rate_fixed_term]
+        ]
+      ]
+    end
+
+    it 'sorts the rates by job type' do
+      expect(helper.grouped_rates_sorted_by_job_type(unsorted_grouped_rates)).to eq(sorted_grouped_rates)
+    end
+  end
+
+  describe '.agency_rate_cell' do
+    let(:result) { helper.agency_rate_cell(rate) }
+
+    context 'when the rate is a percentage' do
+      let(:rate) { rate_over_12_week }
+
+      it 'returns the rate as a percentage' do
+        expect(result).to eq('<td class="govuk-table__cell govuk-table__cell--numeric agency-record__markup-column">30.0%</td>')
+      end
+    end
+
+    context 'when the rate is a price' do
+      let(:rate) { rate_nominated }
+
+      it 'returns the rate as a price' do
+        expect(result).to eq('<td class="govuk-table__cell govuk-table__cell--numeric agency-record__markup-column">£30.00</td>')
+      end
+    end
+  end
+
+  describe '.agency_sorted_rates' do
+    it 'returns the rates sorted by the term' do
+      expect(helper.agency_sorted_rates([rate_teacher_2, rate_teacher_1])).to eq([rate_teacher_1, rate_teacher_2])
+    end
+  end
+end

--- a/spec/models/supply_teachers/rm6238/rate_spec.rb
+++ b/spec/models/supply_teachers/rm6238/rate_spec.rb
@@ -226,8 +226,8 @@ RSpec.describe SupplyTeachers::RM6238::Rate, type: :model do
     context 'and the job_type is over_12_week' do
       let(:job_type) { 'over_12_week' }
 
-      context 'and the term is daily' do
-        let(:term) { 'daily' }
+      context 'and the term is blank' do
+        let(:term) { '' }
 
         it 'is valid' do
           expect(rate).to be_valid
@@ -238,30 +238,10 @@ RSpec.describe SupplyTeachers::RM6238::Rate, type: :model do
         end
       end
 
-      context 'and the term is six_weeks_plus' do
-        let(:term) { 'six_weeks_plus' }
+      context 'and the term is not blank' do
+        let(:term) { 'daily' }
 
         it 'is valid' do
-          expect(rate).to be_valid
-        end
-
-        it 'is not a percentage' do
-          expect(rate.percentage?).to be false
-        end
-      end
-
-      context 'and the term is blank' do
-        let(:term) { '' }
-
-        it 'is not valid' do
-          expect(rate).not_to be_valid
-        end
-      end
-
-      context 'and the term is not in the list' do
-        let(:term) { 'invalid-term-type' }
-
-        it 'is not valid' do
           expect(rate).not_to be_valid
         end
       end


### PR DESCRIPTION
Ticket: [FMFR-1288](https://crowncommercialservice.atlassian.net/browse/FMFR-1288)

This change makes sure that the rates are shown in the right order (based on the role). In addition I’ve updated the ‘over_12_weeks’ role as this no longer has a term (this is a change from what was in the original pricing data given to us).

I have added/updated specs/features to reflect these changes
