### PR TITLE
FMFR-1289 - Make sure only lot 1 rates are shown

### DIFF
--- a/app/models/supply_teachers/rm6238/supplier.rb
+++ b/app/models/supply_teachers/rm6238/supplier.rb
@@ -51,7 +51,7 @@ module SupplyTeachers
       end
 
       def rates_grouped_by_job_type
-        rates.group_by(&:job_type)
+        rates.direct_provision.group_by(&:job_type)
       end
 
       def direct_provision_rates

--- a/spec/models/supply_teachers/rm6238/supplier_spec.rb
+++ b/spec/models/supply_teachers/rm6238/supplier_spec.rb
@@ -247,6 +247,33 @@ RSpec.describe SupplyTeachers::RM6238::Supplier, type: :model do
     end
   end
 
+  describe '.rates_grouped_by_job_type' do
+    let(:supplier) { create(:supply_teachers_rm6238_supplier) }
+    let!(:rate_teacher_1) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'teacher', term: 'daily') }
+    let!(:rate_teacher_2) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'teacher', term: 'six_weeks_plus') }
+    let!(:rate_support_1) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'support', term: 'daily') }
+    let!(:rate_support_2) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'support', term: 'six_weeks_plus') }
+    let!(:rate_nominated) { create(:supply_teachers_rm6238_rate, supplier: supplier, job_type: 'nominated') }
+
+    let(:lot_1_grouped_rates) do
+      {
+        'teacher' => [rate_teacher_1, rate_teacher_2],
+        'support' => [rate_support_1, rate_support_2],
+        'nominated' => [rate_nominated]
+      }
+    end
+
+    before do
+      create(:supply_teachers_rm6238_master_vendor_below_threshold_rate, supplier: supplier, job_type: 'teacher', term: 'daily')
+      create(:supply_teachers_rm6238_master_vendor_below_threshold_rate, supplier: supplier, job_type: 'teacher', term: 'six_weeks_plus')
+      create(:supply_teachers_rm6238_education_technology_platforms_rate, supplier: supplier, job_type: 'agency_management', term: 'daily')
+    end
+
+    it 'returns only the rates in lot 1 gouped by job' do
+      expect(supplier.rates_grouped_by_job_type).to eq(lot_1_grouped_rates)
+    end
+  end
+
   describe '.rate_for' do
     let(:rate) { supplier.rate_for(job_type: SupplyTeachers::RM6238::JobType.find_role_by(code: job_type), term: SupplyTeachers::RM6238::Term.find_by(code: term)) }
 


### PR DESCRIPTION
Ticket: [FMFR-1289](https://crowncommercialservice.atlassian.net/browse/FMFR-1289)

When we get the grouped rates, we make sure we only select the rates belonging to lot 1.