### PR TITLE
FMFR-1294 - Update the dates for the ST frameworks

### DIFF
--- a/lib/tasks/frameworks.rake
+++ b/lib/tasks/frameworks.rake
@@ -1,10 +1,9 @@
 module Frameworks
-  def self.rm6238_live_at
+  def self.rm3826_expires_at
     if Rails.env.test?
-      Time.zone.now - 1.day
+      Time.zone.now + 1.year
     else
-      # This is not correct but it is far in the future and we can update it with another migration later on
-      Time.new(2025, 9, 1).in_time_zone('London')
+      Time.new(2022, 9, 12).in_time_zone('London')
     end
   end
 
@@ -37,8 +36,8 @@ module Frameworks
 
   def self.add_frameworks
     ActiveRecord::Base.connection.truncate_tables(:frameworks)
-    Framework.create(service: 'supply_teachers', framework: 'RM3826', live_at: Time.new(2020, 6, 26).in_time_zone('London'), expires_at: Time.new(2025, 6, 26).in_time_zone('London'))
-    Framework.create(service: 'supply_teachers', framework: 'RM6238', live_at: rm6238_live_at, expires_at: rm6238_expires_at)
+    Framework.create(service: 'supply_teachers', framework: 'RM3826', live_at: Time.new(2020, 6, 26).in_time_zone('London'), expires_at: rm3826_expires_at)
+    Framework.create(service: 'supply_teachers', framework: 'RM6238', live_at: Time.new(2022, 9, 12).in_time_zone('London'), expires_at: rm6238_expires_at)
     Framework.create(service: 'management_consultancy', framework: 'RM6187', live_at: Time.new(2021, 9, 4).in_time_zone('London'), expires_at: Time.new(2025, 9, 4).in_time_zone('London'))
     Framework.create(service: 'legal_services', framework: 'RM3788', live_at: Time.new(2020, 6, 26).in_time_zone('London'), expires_at: Time.new(2025, 6, 26).in_time_zone('London'))
     Framework.create(service: 'legal_services', framework: 'RM6240', live_at: rm6240_live_at, expires_at: rm6240_expires_at)


### PR DESCRIPTION
Ticket: [FMFR-1294](https://crowncommercialservice.atlassian.net/browse/FMFR-1294)

I have updated the dates in the for supply teachers in the tool so they are accurate. This will mean if the `rake db:legacy_frameworks` command is run, it will make sure both the old and the new framework are in their correct states.

I’ve changed the ephesus on the old framework so that it is closed by default but open in tests. In a feature release we may want to remove the old framework, but I have left it as it is until that decision is made.