### PR TITLE
FMFR-1308 - Fix issue with document download in legal services

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -244,5 +244,13 @@ module ApplicationHelper
       current_cookie_preferences.empty? ? Marketplace.default_cookie_options : current_cookie_preferences
     end
   end
+
+  def admin_upload_file(upload, attachment, service, framework)
+    "#{rails_blob_path(attachment, disposition: 'attachment', key: "#{service}_#{framework}_upload_id".to_sym, value: upload.id)}&format=#{get_file_extension(attachment)}"
+  end
+
+  def get_file_extension(file)
+    file.filename.extension_without_delimiter.to_sym
+  end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/helpers/supply_teachers/admin/uploads_helper.rb
+++ b/app/helpers/supply_teachers/admin/uploads_helper.rb
@@ -22,10 +22,6 @@ module SupplyTeachers::Admin::UploadsHelper
     end
   end
 
-  def get_file_extension(file)
-    file.filename.extension_without_delimiter.to_sym
-  end
-
   def upload_status_tag(status)
     colour = case status
              when 'published', 'files_processed'
@@ -37,10 +33,6 @@ module SupplyTeachers::Admin::UploadsHelper
              end
 
     [colour, t("supply_teachers.admin.uploads.state.#{status}")]
-  end
-
-  def st_file_link(upload, attachment)
-    "#{rails_blob_path(attachment, disposition: 'attachment', key: "st_#{params[:framework].downcase}_upload_id".to_sym, value: upload.id)}&format=#{get_file_extension(attachment)}"
   end
 
   def expected_file_type(attachment)

--- a/app/models/legal_services/admin/upload.rb
+++ b/app/models/legal_services/admin/upload.rb
@@ -1,6 +1,8 @@
 module LegalServices
   module Admin
     class Upload < ::Admin::Upload
+      self.abstract_class = true
+
       has_one_attached :supplier_details_file
       has_one_attached :supplier_rate_cards_file
       has_one_attached :supplier_lot_1_service_offerings_file

--- a/app/views/legal_services/admin/uploads/index.html.erb
+++ b/app/views/legal_services/admin/uploads/index.html.erb
@@ -32,7 +32,7 @@
             <tr>
               <td class="govuk-table__cell"><%= t(".file_name.#{file}") %></td>
               <td class="govuk-table__cell"><%= format_date_time @latest_upload.created_at %></td>
-              <td class="govuk-table__cell"><%= link_to t('.download'), "#{rails_blob_path(@latest_upload.send(file), disposition: 'attachment', key: :"ls_#{params[:framework].downcase}_upload_id", value: @latest_upload.id)}&format=xlsx", download: '' %></td>
+              <td class="govuk-table__cell"><%= link_to t('.download'), admin_upload_file(@latest_upload, @latest_upload.send(file), :ls, params[:framework].downcase), download: '' %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/legal_services/admin/uploads/show.html.erb
+++ b/app/views/legal_services/admin/uploads/show.html.erb
@@ -46,7 +46,7 @@
           <% next unless @upload.send(file).attached? %>
           <tr>
             <td class="govuk-table__cell"><%= t(".file_name.#{file}") %></td>
-            <td class="govuk-table__cell"><%= link_to t('.download'), "#{rails_blob_path(@upload.send(file), disposition: 'attachment', key: :"ls_#{params[:framework].downcase}_upload_id", valud: @upload.id)}&format=xlsx", download: '' %></td>
+            <td class="govuk-table__cell"><%= link_to t('.download'), admin_upload_file(@upload, @upload.send(file), :ls, params[:framework].downcase), download: '' %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/management_consultancy/rm6187/admin/uploads/index.html.erb
+++ b/app/views/management_consultancy/rm6187/admin/uploads/index.html.erb
@@ -32,7 +32,7 @@
             <tr>
               <td class="govuk-table__cell"><%= t(".file_name.#{file}") %></td>
               <td class="govuk-table__cell"><%= format_date_time @latest_upload.created_at %></td>
-              <td class="govuk-table__cell"><%= link_to t('.download'), "#{rails_blob_path(@latest_upload.send(file), disposition: 'attachment', key: :"mc_#{params[:framework].downcase}_upload_id", value: @latest_upload.id)}&format=xlsx", download: '' %></td>
+              <td class="govuk-table__cell"><%= link_to t('.download'), admin_upload_file(@latest_upload, @latest_upload.send(file), :mc, params[:framework].downcase), download: '' %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/management_consultancy/rm6187/admin/uploads/show.html.erb
+++ b/app/views/management_consultancy/rm6187/admin/uploads/show.html.erb
@@ -46,7 +46,7 @@
           <% next unless @upload.send(file).attached? %>
           <tr>
             <td class="govuk-table__cell"><%= t(".file_name.#{file}") %></td>
-            <td class="govuk-table__cell"><%= link_to t('.download'), "#{rails_blob_path(@upload.send(file), disposition: 'attachment', key: :"mc_#{params[:framework].downcase}_upload_id", value: @upload.id)}&format=xlsx", download: '' %></td>
+            <td class="govuk-table__cell"><%= link_to t('.download'), admin_upload_file(@upload, @upload.send(file), :mc, params[:framework].downcase), download: '' %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/supply_teachers/admin/uploads/_current_upload.html.erb
+++ b/app/views/supply_teachers/admin/uploads/_current_upload.html.erb
@@ -3,6 +3,6 @@
     <td class="govuk-table__cell"><%= current_upload[:attribute_name].to_s.humanize %></td>
     <td class="govuk-table__cell"><%= link_to t('.upload_name', number: current_upload[:upload].short_uuid), current_upload[:upload] %></td>
     <td class="govuk-table__cell"><%= format_date_time current_upload[:upload].created_at %></td>
-    <td class="govuk-table__cell"><%= link_to 'Download', st_file_link(current_upload[:upload], current_upload[:attachment]), download: '' %></td>
+    <td class="govuk-table__cell"><%= link_to 'Download', admin_upload_file(current_upload[:upload], current_upload[:attachment], :st, params[:framework].downcase), download: '' %></td>
   </tr>
 <% end %>

--- a/app/views/supply_teachers/admin/uploads/show.html.erb
+++ b/app/views/supply_teachers/admin/uploads/show.html.erb
@@ -61,7 +61,7 @@
         <% if @upload.send(attribute).attached? %>
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="row"><%= t(".#{attribute.to_s}") %></th>
-            <td class="govuk-table__cell"><%= link_to 'Download', st_file_link(@upload, @upload.send(attribute)), download: '' %></td>
+            <td class="govuk-table__cell"><%= link_to 'Download', admin_upload_file(@upload, @upload.send(attribute), :st, params[:framework].downcase), download: '' %></td>
           </tr>
         <% end %>
       <% end %>

--- a/db/migrate/20220929130611_fix_issue_with_ls_uploads.rb
+++ b/db/migrate/20220929130611_fix_issue_with_ls_uploads.rb
@@ -1,0 +1,25 @@
+class FixIssueWithLsUploads < ActiveRecord::Migration[6.0]
+  def up
+    ActiveStorage::Attachment.where(record_type: 'LegalServices::Admin::Upload').find_in_batches do |attachment_group|
+      sleep(5)
+
+      attachment_group.each do |attachment|
+        new_record_type = ''
+
+        if LegalServices::RM3788::Admin::Upload.find_by(id: attachment.record_id)
+          new_record_type = 'LegalServices::RM3788::Admin::Upload'
+        elsif LegalServices::RM6240::Admin::Upload.find_by(id: attachment.record_id)
+          new_record_type = 'LegalServices::RM6240::Admin::Upload'
+        else
+          Rails.logger.warn("Could not find LegalServices::Admin::Upload for #{attachment.record_id}")
+
+          next
+        end
+
+        attachment.update(record_type: new_record_type)
+      end
+    end
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_08_134204) do
+ActiveRecord::Schema.define(version: 2022_09_29_130611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -309,4 +309,47 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe 'admin upload methods' do
+    let(:upload) do
+      admin_upload = build(:supply_teachers_rm6238_admin_upload)
+      admin_upload.update(current_accredited_suppliers: create_file(*FILE_PARAMS[:valid_xlsx]))
+      admin_upload.update(master_vendor_contacts: create_file(*FILE_PARAMS[:valid_csv]))
+      admin_upload
+    end
+
+    let(:created_files) { [] }
+
+    def create_file(extension, content)
+      temp_file = Tempfile.new(['supplier_data', ".#{extension}"])
+      created_files << temp_file
+
+      fixture_file_upload(temp_file.path, content)
+    end
+
+    after { created_files.each(&:unlink) }
+
+    context 'when considering admin_upload_file' do
+      it 'the path has the expected params' do
+        uri_params = CGI.parse(URI.parse(helper.admin_upload_file(upload, upload.current_accredited_suppliers, :st, 'RM6238')).query)
+
+        expect(uri_params).to eq({
+                                   'disposition' => ['attachment'],
+                                   'key' => ['st_RM6238_upload_id'],
+                                   'value' => [upload.id],
+                                   'format' => ['xlsx']
+                                 })
+      end
+    end
+
+    context 'when considering get_file_extension' do
+      it 'returns xlsx for current_accredited_suppliers' do
+        expect(helper.get_file_extension(upload.current_accredited_suppliers)).to eq :xlsx
+      end
+
+      it 'returns csv for master_vendor_contacts' do
+        expect(helper.get_file_extension(upload.master_vendor_contacts)).to eq :csv
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: [FMFR-1308](https://crowncommercialservice.atlassian.net/browse/FMFR-1308)

Fix an issue where legal services documents could not be downloaded in the admin tool. As all three services download files in the same way, I have created a helper to format the url for the document download to avoid this error in the future.

I have added some specs for this method.