### PR TITLE
FMFR-1320 - Fix issue with MFA when signing in for the first time

### DIFF
--- a/app/helpers/base/sessions_helper.rb
+++ b/app/helpers/base/sessions_helper.rb
@@ -4,7 +4,11 @@ module Base::SessionsHelper
   end
 
   HEADER_TEXT = {
-    'management_consultancy' => I18n.t('base.sessions.new.heading.management_consultancy'),
-    'legal_services' => I18n.t('base.sessions.new.heading.legal_services')
+    'management_consultancy' => I18n.t('base.sessions.new.heading.management_consultancy.buyer'),
+    'management_consultancy/admin' => I18n.t('base.sessions.new.heading.management_consultancy.admin'),
+    'legal_services' => I18n.t('base.sessions.new.heading.legal_services.buyer'),
+    'legal_services/admin' => I18n.t('base.sessions.new.heading.legal_services.admin'),
+    'supply_teachers' => I18n.t('base.sessions.new.heading.supply_teachers.buyer'),
+    'supply_teachers/admin' => I18n.t('base.sessions.new.heading.supply_teachers.admin')
   }.freeze
 end

--- a/app/services/cognito/respond_to_challenge.rb
+++ b/app/services/cognito/respond_to_challenge.rb
@@ -4,14 +4,17 @@ module Cognito
     attr_reader :challenge_name, :username, :session, :new_password, :new_password_confirmation, :access_code, :roles
 
     # new password validations
-    validates :new_password,
-              presence: true,
-              confirmation: { case_sensitive: true },
-              length: { within: 8..200 },
-              if: :new_password_challenge?
-    validates_presence_of :new_password_confirmation, if: :new_password_challenge?
-    validates_format_of :new_password, with: /(?=.*[A-Z])/, message: :invalid_no_capitals, if: :new_password_challenge?
-    validates_format_of :new_password, with: /(?=.*\W)/, message: :invalid_no_symbol, if: :new_password_challenge?
+    with_options if: :new_password_challenge? do
+      validates :new_password,
+                presence: true,
+                confirmation: { case_sensitive: true },
+                length: { within: 8..200 }
+      validates_format_of :new_password, with: /(?=.*[A-Z])/, message: :invalid_no_capitals
+      validates_format_of :new_password, with: /(?=.*\W)/, message: :invalid_no_symbol
+      validates_format_of :new_password, with: /(?=.*[0-9])/, message: :invalid_no_number
+
+      validates_presence_of :new_password_confirmation
+    end
 
     # sms mfa validations
     validates :access_code,
@@ -49,7 +52,7 @@ module Cognito
     end
 
     def cognito_uuid
-      @response.challenge_parameters['USER_ID_FOR_SRP']
+      @username
     end
 
     def new_session

--- a/app/views/base/passwords/edit.html.erb
+++ b/app/views/base/passwords/edit.html.erb
@@ -52,7 +52,7 @@
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:confirmation_code].any? %>">
-          <label class="govuk-label" for="password02">
+          <label class="govuk-label" for="confirmation-code">
             <%= t('.verify_code') %>
           </label>
 

--- a/app/views/base/sessions/new.html.erb
+++ b/app/views/base/sessions/new.html.erb
@@ -1,11 +1,9 @@
-<% unless local_header_text.nil? %>
-  <%= content_for :page_title, local_header_text %>
-  <h1 class="govuk-heading-xl">
-    <%= local_header_text %>
-  </h1>
-<% end %>
+<%= content_for :page_title, local_header_text %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= local_header_text %>
+    </h1>
 
     <%= render partial: 'shared/error_summary', locals: { errors: @result.errors } %>
 
@@ -41,7 +39,7 @@
 
     <% end %>
 
-    <% unless local_header_text.nil? %>
+    <% if params[:service] == 'legal_services' ||   params[:service] == 'management_consultancy' %>
       <p class="govuk-body govuk-!-margin-bottom-7">
         <%= link_to t('.create_ccs_account_html'), sign_up_path, class: "govuk-link" %>
       </p>

--- a/app/views/base/users/confirm_new.html.erb
+++ b/app/views/base/users/confirm_new.html.erb
@@ -24,7 +24,7 @@
       </div>
 
       <% if cookies[:crown_marketplace_confirmation_email] %>
-        <%= hidden_field_tag :email, cookies[:crown_marketplace_confirmation_email] %>
+        <%= hidden_field_tag :email, cookies[:crown_marketplace_confirmation_email], id: 'email' %>
       <% else %>
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @result.errors[:email].any? %>">
           <label class="govuk-label" for="email">
@@ -42,7 +42,7 @@
 
     <% if cookies[:crown_marketplace_confirmation_email] %>
       <%= form_tag resend_confirmation_email_path, class: 'ccs-form', id: 'cop_resend_confirmation_code', specialvalidation: true, novalidate: true, method: :post do %>
-        <%= hidden_field_tag :email, cookies[:crown_marketplace_confirmation_email] %>
+        <%= hidden_field_tag :email, cookies[:crown_marketplace_confirmation_email], id: 'resend-email' %>
     
         <p class="govuk-body govuk-!-margin-bottom-7">
           <%= submit_tag t('.resend_the_confirmation_email'), id: "resend-the-confirmation-email", class: "govuk-link button_as_link", aria: { label: t('.resend_the_confirmation_email') } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
             new_password:
               blank: Enter a password
               invalid_no_capitals: Password must include a capital letter
+              invalid_no_number: Password must include a number
               invalid_no_symbol: Password must include a special character
               too_short: Password must be 8 characters or more
             new_password_confirmation:
@@ -121,8 +122,15 @@ en:
         enter_your_password: Enter your password
         forgotten_password_html: I’ve forgotten my password
         heading:
-          legal_services: Sign in to your legal services buyer account
-          management_consultancy: Sign in to your management consultancy buyer account
+          legal_services:
+            admin: Sign in to your legal services admin account
+            buyer: Sign in to your legal services account
+          management_consultancy:
+            admin: Sign in to your management consultancy admin account
+            buyer: Sign in to your management consultancy account
+          supply_teachers:
+            admin: Sign in to your supply teachers admin account
+            buyer: Sign in to your supply teachers account
         password: Password
         please_enter_a_valid_email_address: You must provide your email address in the correct format, like name@example.com
         problems_signing_in: Problems signing in

--- a/data/spec_templates/users_controller_spec.txt
+++ b/data/spec_templates/users_controller_spec.txt
@@ -147,7 +147,7 @@ RSpec.describe <module_service_name>::UsersController, type: :controller do
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/features/accessibility/legal_services/rm3788/home/start_pages_accessibility.feature
+++ b/features/accessibility/legal_services/rm3788/home/start_pages_accessibility.feature
@@ -10,7 +10,7 @@ Feature: Legal Services - Start pages accessibility
     When I go to the 'legal services' start page for 'RM3788'
     Then I am on the 'Find legal services for the wider public sector' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     Then the page should be axe clean
 
   Scenario: Start page

--- a/features/accessibility/legal_services/rm6240/cognito/forgot_password.feature
+++ b/features/accessibility/legal_services/rm6240/cognito/forgot_password.feature
@@ -1,0 +1,11 @@
+@accessibility @javascript
+Feature: Forgot my password - Legal Services - RM6240 - Accessibility
+
+  Scenario: Reset password page
+    When I go to the 'legal services' start page for 'RM6240'
+    Then I am on the 'Find legal services for the wider public sector' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your legal services account' page
+    When I click on 'I’ve forgotten my password'
+    Then I am on the 'Reset password' page
+    Then the page should be axe clean

--- a/features/accessibility/legal_services/rm6240/cognito/sign_in.feature
+++ b/features/accessibility/legal_services/rm6240/cognito/sign_in.feature
@@ -1,0 +1,52 @@
+@accessibility @javascript
+Feature: Sign in to my account - Legal Services - RM6240 - Accessibility
+
+  Background: Navigate to the sign in page
+    When I go to the 'legal services' start page for 'RM6240'
+    Then I am on the 'Find legal services for the wider public sector' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your legal services account' page
+
+  Scenario: Sign in page
+    Then the page should be axe clean
+
+  Scenario: Enter your access code page
+    Then I should sign in with MFA and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    Then the page should be axe clean
+
+  Scenario: Change your password page
+    Then I should sign in for the first time with the roles:
+      | ls_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    Then the page should be axe clean
+
+  Scenario: Activate your account page
+    Then I should sign in as user who just created their account and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Activate your account' page
+    Then the page should be axe clean
+
+  Scenario: Reset your password page
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    Then the page should be axe clean
+
+  Scenario: You have successfully changed your password page
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I am on the 'You have successfully changed your password' page
+    Then the page should be axe clean

--- a/features/accessibility/legal_services/rm6240/cognito/sign_up_user.feature
+++ b/features/accessibility/legal_services/rm6240/cognito/sign_up_user.feature
@@ -1,0 +1,11 @@
+@accessibility @javascript
+Feature: Sign up to legal services - RM6240 - Accessibility
+
+  Scenario: Create an account page
+    When I go to the 'legal services' start page for 'RM6240'
+    Then I am on the 'Find legal services for the wider public sector' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your legal services account' page
+    And I click on 'Create an account'
+    Then I am on the 'Create a CCS account' page
+    Then the page should be axe clean

--- a/features/accessibility/legal_services/rm6240/home/start_pages_accessibility.feature
+++ b/features/accessibility/legal_services/rm6240/home/start_pages_accessibility.feature
@@ -10,7 +10,7 @@ Feature: Legal Services - Start pages accessibility
     When I go to the 'legal services' start page for 'RM6240'
     Then I am on the 'Find legal services for the wider public sector' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     Then the page should be axe clean
 
   Scenario: Start page

--- a/features/accessibility/management_consultancy/rm6187/cognito/forgot_password.feature
+++ b/features/accessibility/management_consultancy/rm6187/cognito/forgot_password.feature
@@ -1,0 +1,11 @@
+@accessibility @javascript
+Feature: Forgot my password - Management Consultancy - RM6187 - Accessibility
+
+  Scenario: I forgot my password
+    When I go to the 'management consultancy' start page for 'RM6187'
+    Then I am on the 'Find management consultants' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your management consultancy account' page
+    When I click on 'I’ve forgotten my password'
+    Then I am on the 'Reset password' page
+    Then the page should be axe clean

--- a/features/accessibility/management_consultancy/rm6187/cognito/sign_in.feature
+++ b/features/accessibility/management_consultancy/rm6187/cognito/sign_in.feature
@@ -1,0 +1,52 @@
+@accessibility @javascript
+Feature: Sign in to my account - Management Consultancy - RM6187 - Accessibility
+
+  Background: Navigate to the sign in page
+    When I go to the 'management consultancy' start page for 'RM6187'
+    Then I am on the 'Find management consultants' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your management consultancy account' page
+
+  Scenario: Sign in page
+    Then the page should be axe clean
+
+  Scenario: Enter your access code page
+    Then I should sign in with MFA and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    Then the page should be axe clean
+
+  Scenario: Change your password page
+    Then I should sign in for the first time with the roles:
+      | mc_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    Then the page should be axe clean
+
+  Scenario: Activate your account page
+    Then I should sign in as user who just created their account and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Activate your account' page
+    Then the page should be axe clean
+
+  Scenario: Reset your password page
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    Then the page should be axe clean
+
+  Scenario: You have successfully changed your password page
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I am on the 'You have successfully changed your password' page
+    Then the page should be axe clean

--- a/features/accessibility/management_consultancy/rm6187/cognito/sign_up_user.feature
+++ b/features/accessibility/management_consultancy/rm6187/cognito/sign_up_user.feature
@@ -1,0 +1,11 @@
+@accessibility @javascript
+Feature: Sign up to management consultancy - RM6187 - Accessibility
+
+  Scenario: Create an account page
+    When I go to the 'management consultancy' start page for 'RM6187'
+    Then I am on the 'Find management consultants' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your management consultancy account' page
+    And I click on 'Create an account'
+    Then I am on the 'Create a CCS account' page
+    Then the page should be axe clean

--- a/features/accessibility/management_consultancy/rm6187/home/start_pages_accessibility.feature
+++ b/features/accessibility/management_consultancy/rm6187/home/start_pages_accessibility.feature
@@ -10,7 +10,7 @@ Feature: Management Consultancy - Start pages accessibility
     When I go to the 'management consultancy' start page for 'RM6187'
     Then I am on the 'Find management consultants' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your management consultancy buyer account' page
+    Then I am on the 'Sign in to your management consultancy account' page
     Then the page should be axe clean
 
   Scenario: Start page

--- a/features/accessibility/supply_teachers/rm6238/cognito/forgot_password.feature
+++ b/features/accessibility/supply_teachers/rm6238/cognito/forgot_password.feature
@@ -1,0 +1,13 @@
+@accessibility @javascript
+Feature: Forgot my password - Supply Teachers - RM6238 - Accessibility
+
+  Scenario: I forgot my password
+    When I go to the 'supply teachers' start page for 'RM6238'
+    Then I am on the 'Find supply teachers and agency workers' page
+    When I click on 'Start now'
+    Then I am on the 'Sign in to find supply teachers and agency workers' page
+    And I click on 'Sign in with CCS'
+    And I am on the 'Sign in to your supply teachers account' page
+    When I click on 'I’ve forgotten my password'
+    Then I am on the 'Reset password' page
+    Then the page should be axe clean

--- a/features/accessibility/supply_teachers/rm6238/cognito/sign_in.feature
+++ b/features/accessibility/supply_teachers/rm6238/cognito/sign_in.feature
@@ -1,0 +1,47 @@
+@accessibility @javascript
+Feature: Sign in to my account - Supply Teachers - RM6238 - Accessibility
+
+  Background: Navigate to the sign in page
+    When I go to the 'supply teachers' start page for 'RM6238'
+    Then I am on the 'Find supply teachers and agency workers' page
+    When I click on 'Start now'
+    Then I am on the 'Sign in to find supply teachers and agency workers' page
+    And I click on 'Sign in with CCS'
+    And I am on the 'Sign in to your supply teachers account' page
+
+  Scenario: Sign in page
+    Then the page should be axe clean
+
+  Scenario: Enter your access code page
+    Then I should sign in with MFA and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    Then the page should be axe clean
+
+  Scenario: Change your password page
+    Then I should sign in for the first time with the roles:
+      | st_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    Then the page should be axe clean
+
+  Scenario: Reset your password page
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    Then the page should be axe clean
+
+  Scenario: You have successfully changed your password page
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I am on the 'You have successfully changed your password' page
+    Then the page should be axe clean

--- a/features/helpers/cognito_helper.rb
+++ b/features/helpers/cognito_helper.rb
@@ -1,0 +1,305 @@
+def stub_cognito(option, roles)
+  @user_email = Faker::Internet.unique.email
+
+  aws_client = instance_double(Aws::CognitoIdentityProvider::Client)
+  allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+
+  method = "stub_#{option}".to_sym
+
+  send(
+    method,
+    aws_client,
+    {
+      user_email: @user_email,
+      user_cognito_uuid: SecureRandom.uuid,
+      roles: roles
+    }
+  )
+end
+
+def stub_cognito_with_error(option, error_key, roles = [])
+  @user_email = Faker::Internet.unique.email
+
+  aws_client = instance_double(Aws::CognitoIdentityProvider::Client)
+  allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+  allow_any_instance_of(Cognito::SignInUser).to receive(:sleep)
+
+  method = "stub_#{option}_error".to_sym
+
+  send(
+    method,
+    aws_client,
+    {
+      user_email: @user_email,
+      user_cognito_uuid: SecureRandom.uuid,
+      roles: roles
+    },
+    get_aws_error(error_key)
+  )
+end
+
+def get_aws_error(error_key)
+  "Aws::CognitoIdentityProvider::Errors::#{AWS_ERRORS[error_key]}".constantize.new('Some error', "An error occured: #{error_key}")
+end
+
+AWS_ERRORS = {
+  'service' => 'ServiceError',
+  'user not found' => 'UserNotFoundException',
+  'invalid parameter' => 'InvalidParameterException',
+  'username exists' => 'UsernameExistsException',
+  'not authorized' => 'NotAuthorizedException',
+  'code mismatch' => 'CodeMismatchException'
+}.freeze
+
+# Normal cognito paths
+def stub_existing_user(aws_client, user_params)
+  create(:user, email: user_params[:user_email], cognito_uuid: user_params[:user_cognito_uuid], confirmed_at: Time.zone.now, roles: user_params[:roles])
+  allow(aws_client).to receive(:initiate_auth).and_return(OpenStruct.new)
+  stub_adding_to_groups(aws_client, user_params)
+end
+
+def stub_first_time_password_reset(aws_client, user_params)
+  user_params[:session_uuid] = SecureRandom.uuid
+
+  stub_login_with_challange(aws_client, user_params, 'NEW_PASSWORD_REQUIRED')
+
+  allow(aws_client).to receive(:respond_to_auth_challenge).with(**respond_to_auth_challenge_new_password(user_params)).and_return(OpenStruct.new)
+end
+
+def stub_first_time_sms_mfa(aws_client, user_params)
+  user_params[:session_uuid] = SecureRandom.uuid
+
+  stub_login_with_challange(aws_client, user_params, 'NEW_PASSWORD_REQUIRED')
+
+  allow(aws_client).to receive(:respond_to_auth_challenge).with(**respond_to_auth_challenge_new_password(user_params)).and_return(
+    OpenStruct.new(
+      session: user_params[:session_uuid],
+      challenge_name: 'SMS_MFA'
+    )
+  )
+
+  allow(aws_client).to receive(:respond_to_auth_challenge).with(**respond_to_auth_challenge_sms_mfa(user_params)).and_return(OpenStruct.new)
+end
+
+def stub_first_time_confirm_account(aws_client, user_params)
+  create(:user, email: user_params[:user_email], cognito_uuid: user_params[:user_cognito_uuid], confirmed_at: Time.zone.now, roles: user_params[:roles])
+
+  allow(aws_client).to receive(:initiate_auth).with(**initiate_auth(user_params)).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotConfirmedException.new('Some error', 'Some message'))
+
+  allow(aws_client).to receive(:confirm_sign_up).with(**confirm_sign_up(user_params))
+end
+
+def stub_sms_mfa(aws_client, user_params)
+  user_params[:session_uuid] = SecureRandom.uuid
+
+  stub_login_with_challange(aws_client, user_params, 'SMS_MFA')
+
+  allow(aws_client).to receive(:respond_to_auth_challenge).with(**respond_to_auth_challenge_sms_mfa(user_params)).and_return(OpenStruct.new)
+end
+
+def stub_password_reset_required(aws_client, user_params)
+  create(:user, email: user_params[:user_email], cognito_uuid: user_params[:user_cognito_uuid], confirmed_at: Time.zone.now, roles: user_params[:roles])
+
+  allow(aws_client).to receive(:initiate_auth).with(**initiate_auth(user_params)).and_raise(Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException.new('Some error', 'Some message'))
+
+  allow(aws_client).to receive(:confirm_forgot_password).with(**confirm_forgot_password(user_params))
+end
+
+def stub_forgot_password(aws_client, user_params)
+  create(:user, email: user_params[:user_email], cognito_uuid: user_params[:user_cognito_uuid], confirmed_at: Time.zone.now, roles: user_params[:roles])
+
+  allow(aws_client).to receive(:forgot_password).with(**forgot_password(user_params))
+
+  allow(aws_client).to receive(:confirm_forgot_password).with(**confirm_forgot_password(user_params))
+end
+
+def stub_create_an_account(aws_client, user_params)
+  user_params[:user_email] = Faker::Internet.email(domain: 'test.com')
+  @user_email = user_params[:user_email]
+
+  allow(aws_client).to receive(:sign_up).with(**sign_up(user_params)).and_return(
+    {
+      'user_sub' => user_params[:user_cognito_uuid]
+    }
+  )
+
+  user_params[:roles].each do |role|
+    allow(aws_client).to receive(:admin_add_user_to_group).with(
+      user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+      username: user_params[:user_cognito_uuid],
+      group_name: role
+    )
+  end
+
+  allow(aws_client).to receive(:confirm_sign_up).with(**confirm_sign_up(user_params))
+end
+
+# Cognito paths with errors
+def stub_forgot_password_error(aws_client, user_params, error)
+  allow(aws_client).to receive(:forgot_password).with(**forgot_password(user_params)).and_raise(error)
+end
+
+def stub_create_an_account_error(aws_client, user_params, error)
+  user_params[:user_email] = Faker::Internet.email(domain: 'test.com')
+  @user_email = user_params[:user_email]
+
+  allow(aws_client).to receive(:sign_up).with(**sign_up(user_params)).and_raise(error)
+end
+
+def stub_sign_in_error(aws_client, user_params, error)
+  allow(aws_client).to receive(:initiate_auth).with(**initiate_auth(user_params)).and_raise(error)
+end
+
+def stub_sms_mfa_error(aws_client, user_params, error)
+  user_params[:session_uuid] = SecureRandom.uuid
+
+  stub_login_with_challange(aws_client, user_params, 'SMS_MFA')
+
+  allow(aws_client).to receive(:respond_to_auth_challenge).with(**respond_to_auth_challenge_sms_mfa(user_params)).and_raise(error)
+end
+
+def stub_first_time_password_reset_error(aws_client, user_params, error)
+  user_params[:session_uuid] = SecureRandom.uuid
+
+  stub_login_with_challange(aws_client, user_params, 'NEW_PASSWORD_REQUIRED')
+
+  allow(aws_client).to receive(:respond_to_auth_challenge).with(**respond_to_auth_challenge_new_password(user_params)).and_raise(error)
+end
+
+def stub_first_time_sms_mfa_error(aws_client, user_params, error)
+  user_params[:session_uuid] = SecureRandom.uuid
+
+  stub_login_with_challange(aws_client, user_params, 'NEW_PASSWORD_REQUIRED')
+
+  allow(aws_client).to receive(:respond_to_auth_challenge).with(**respond_to_auth_challenge_new_password(user_params)).and_return(
+    OpenStruct.new(
+      session: user_params[:session_uuid],
+      challenge_name: 'SMS_MFA'
+    )
+  )
+
+  allow(aws_client).to receive(:respond_to_auth_challenge).with(**respond_to_auth_challenge_sms_mfa(user_params)).and_raise(error)
+end
+
+def stub_first_time_confirm_account_error(aws_client, user_params, error)
+  create(:user, email: user_params[:user_email], cognito_uuid: user_params[:user_cognito_uuid], confirmed_at: Time.zone.now, roles: user_params[:roles])
+
+  allow(aws_client).to receive(:initiate_auth).with(**initiate_auth(user_params)).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotConfirmedException.new('Some error', 'Some message'))
+
+  allow(aws_client).to receive(:confirm_sign_up).with(**confirm_sign_up(user_params)).and_raise(error)
+end
+
+def stub_password_reset_required_error(aws_client, user_params, error)
+  create(:user, email: user_params[:user_email], cognito_uuid: user_params[:user_cognito_uuid], confirmed_at: Time.zone.now, roles: user_params[:roles])
+
+  allow(aws_client).to receive(:initiate_auth).with(**initiate_auth(user_params)).and_raise(Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException.new('Some error', 'Some message'))
+
+  allow(aws_client).to receive(:confirm_forgot_password).with(**confirm_forgot_password(user_params)).and_raise(error)
+end
+
+# Shared methods
+def stub_login_with_challange(aws_client, user_params, challenge)
+  allow(aws_client).to receive(:initiate_auth).with(**initiate_auth(user_params)).and_return(
+    OpenStruct.new(
+      session: user_params[:session_uuid],
+      challenge_parameters: {
+        'USER_ID_FOR_SRP' => user_params[:user_cognito_uuid]
+      },
+      challenge_name: challenge
+    )
+  )
+
+  allow(aws_client).to receive(:admin_get_user).with(**admin_get_user(user_params)).and_return(
+    OpenStruct.new(
+      user_attributes: [
+        OpenStruct.new(name: 'sub', value: user_params[:user_cognito_uuid]),
+        OpenStruct.new(name: 'email', value: user_params[:user_email])
+      ]
+    )
+  )
+
+  stub_adding_to_groups(aws_client, user_params)
+end
+
+def stub_adding_to_groups(aws_client, user_params)
+  allow(aws_client).to receive(:admin_list_groups_for_user).with(**admin_get_user(user_params)).and_return(
+    OpenStruct.new(
+      groups: user_params[:roles].map { |role| OpenStruct.new(group_name: role) }
+    )
+  )
+end
+
+# Methods which build the params
+def initiate_auth(user_params)
+  {
+    client_id: ENV['COGNITO_CLIENT_ID'],
+    auth_flow: 'USER_PASSWORD_AUTH',
+    auth_parameters: {
+      'USERNAME' => user_params[:user_email],
+      'PASSWORD' => 'ValidPassword'
+    }
+  }
+end
+
+def respond_to_auth_challenge_new_password(user_params)
+  {
+    client_id: ENV['COGNITO_CLIENT_ID'],
+    session: user_params[:session_uuid],
+    challenge_name: 'NEW_PASSWORD_REQUIRED',
+    challenge_responses: {
+      'NEW_PASSWORD' => 'ValidPassword1!',
+      'USERNAME' => user_params[:user_cognito_uuid]
+    }
+  }
+end
+
+def respond_to_auth_challenge_sms_mfa(user_params)
+  {
+    client_id: ENV['COGNITO_CLIENT_ID'],
+    session: user_params[:session_uuid],
+    challenge_name: 'SMS_MFA',
+    challenge_responses: {
+      'SMS_MFA_CODE' => '123456',
+      'USERNAME' => user_params[:user_cognito_uuid]
+    }
+  }
+end
+
+def confirm_sign_up(user_params)
+  {
+    confirmation_code: '123456'
+  }.merge(forgot_password(user_params))
+end
+
+def confirm_forgot_password(user_params)
+  {
+    password: 'ValidPassword1!',
+    confirmation_code: '123456'
+  }.merge(forgot_password(user_params))
+end
+
+def forgot_password(user_params)
+  {
+    client_id: ENV['COGNITO_CLIENT_ID'],
+    username: user_params[:user_email]
+  }
+end
+
+def sign_up(user_params)
+  {
+    password: 'ValidPassword1!',
+    user_attributes: [
+      {
+        name: 'email',
+        value: user_params[:user_email]
+      }
+    ]
+  }.merge(forgot_password(user_params))
+end
+
+def admin_get_user(user_params)
+  {
+    user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+    username: user_params[:user_cognito_uuid]
+  }
+end

--- a/features/services/legal_services/rm3788/home/cookie_settings.feature
+++ b/features/services/legal_services/rm3788/home/cookie_settings.feature
@@ -14,7 +14,7 @@ Feature: Legal Services - Cookie settings
     When I click on 'Accept analytics cookies'
     Then the cookie banner shows I have 'accepted' the cookies
     And I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     And the cookie banner 'is not' visible
     And the cookies have been saved
     And the 'ga' cookies have been 'accepted'
@@ -24,7 +24,7 @@ Feature: Legal Services - Cookie settings
     When I click on 'Reject analytics cookies'
     Then the cookie banner shows I have 'rejected' the cookies
     And I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     And the cookie banner 'is not' visible
     And the cookies have been saved
     And the 'ga' cookies have been 'rejected'

--- a/features/services/legal_services/rm3788/home/navigation_links/navigation_links_signed_out.feature
+++ b/features/services/legal_services/rm3788/home/navigation_links/navigation_links_signed_out.feature
@@ -14,7 +14,7 @@ Feature: Legal Services - Navigation links when signed out
 
   Scenario: Sign in page 
     And I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     And I should see the following navigation links:
       | Back to start |
     And I click on 'Back to start'

--- a/features/services/legal_services/rm3788/home/start_pages.feature
+++ b/features/services/legal_services/rm3788/home/start_pages.feature
@@ -9,12 +9,12 @@ Feature: Legal Services - Start pages
     When I go to the 'legal services' start page for 'RM3788'
     Then I am on the 'Find legal services for the wider public sector' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
 
   Scenario: Logging in
     When I go to the 'legal services' start page for 'RM3788'
     Then I am on the 'Find legal services for the wider public sector' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     Then I should sign in as an 'ls' buyer
     Then I am on the 'Do you work for central government?' page

--- a/features/services/legal_services/rm3788/home/validations/sign_up_user_validations.feature
+++ b/features/services/legal_services/rm3788/home/validations/sign_up_user_validations.feature
@@ -5,7 +5,7 @@ Feature: Legal Services - Sign up user
     Given I go to the 'legal services' start page for 'RM3788'
     And I am on the 'Find legal services for the wider public sector' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     And I click on 'Create an account'
     Then I am on the 'Create a CCS account' page
 

--- a/features/services/legal_services/rm6240/cognito/forgot_password.feature
+++ b/features/services/legal_services/rm6240/cognito/forgot_password.feature
@@ -1,0 +1,22 @@
+@pipeline
+Feature: Forgot my password - Legal Services - RM6240
+
+  Scenario: I forgot my password
+    When I go to the 'legal services' start page for 'RM6240'
+    Then I am on the 'Find legal services for the wider public sector' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your legal services account' page
+    When I click on 'I’ve forgotten my password'
+    Then I am on the 'Reset password' page
+    And I can reset my password with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I am on the 'You have successfully changed your password' page
+    And I click on 'Sign in'
+    And I am on the 'Sign in to your legal services account' page

--- a/features/services/legal_services/rm6240/cognito/sign_in.feature
+++ b/features/services/legal_services/rm6240/cognito/sign_in.feature
@@ -1,0 +1,74 @@
+@pipeline
+Feature: Sign in to my account - Legal Services - RM6240
+
+  Background: Navigate to the sign in page
+    When I go to the 'legal services' start page for 'RM6240'
+    Then I am on the 'Find legal services for the wider public sector' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your legal services account' page
+
+  Scenario: I sign in to my existing account
+    Then I should sign in with the roles:
+      | ls_access |
+      | buyer     |
+    And I am on the 'Do you work for central government?' page
+
+  Scenario: I sign in with MFA
+    Then I should sign in with MFA and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456 |
+    And I click on 'Continue'
+    Then I am on the 'Do you work for central government?' page
+
+  Scenario: I sign in for the first time
+    Then I should sign in for the first time with the roles:
+      | ls_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter the following details into the form:
+      | Create a password you'll remember | ValidPassword1! |
+      | Confirm your password             | ValidPassword1! |
+    And I click on 'Change password and sign in'
+    Then I am on the 'Do you work for central government?' page
+
+  Scenario: I sign in for the first time with MFA
+    Then I should sign in for the first time with MFA Enabled and with the roles:
+      | ls_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter the following details into the form:
+      | Create a password you'll remember | ValidPassword1! |
+      | Confirm your password             | ValidPassword1! |
+    And I click on 'Change password and sign in'
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456 |
+    And I click on 'Continue'
+    Then I am on the 'Do you work for central government?' page
+
+  Scenario: I sign in for the first time after creating an account
+    Then I should sign in as user who just created their account and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Activate your account' page
+    And I enter the following details into the form:
+      | Confirmation code | 123456 |
+    And I click on 'Continue'
+    Then I am on the 'Do you work for central government?' page
+
+  Scenario: I sign in and need to reset my password
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I am on the 'You have successfully changed your password' page
+    And I click on 'Sign in'
+    And I am on the 'Sign in to your legal services account' page

--- a/features/services/legal_services/rm6240/cognito/sign_up_user.feature
+++ b/features/services/legal_services/rm6240/cognito/sign_up_user.feature
@@ -1,0 +1,16 @@
+@allow_list @pipeline
+Feature: Sign up to legal services - RM6240
+
+  Scenario: I sign in to my existing account
+    When I go to the 'legal services' start page for 'RM6240'
+    Then I am on the 'Find legal services for the wider public sector' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your legal services account' page
+    And I click on 'Create an account'
+    Then I am on the 'Create a CCS account' page
+    And I am able to create an 'ls' account
+    Then I am on the 'Activate your account' page
+    And I enter the following details into the form:
+      | Confirmation code | 123456 |
+    And I click on 'Continue'
+    Then I am on the 'Do you work for central government?' page

--- a/features/services/legal_services/rm6240/cognito/validations/forgot_password_validations.feature
+++ b/features/services/legal_services/rm6240/cognito/validations/forgot_password_validations.feature
@@ -1,0 +1,37 @@
+@pipeline
+Feature: Forgot my password - Legal Services - RM6240 - Validations
+
+  Background: Navigate to forgot password
+    When I go to the 'legal services' start page for 'RM6240'
+    Then I am on the 'Find legal services for the wider public sector' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your legal services account' page
+    When I click on 'I’ve forgotten my password'
+    Then I am on the 'Reset password' page
+
+  Scenario Outline: I forgot my password - email invalid
+    And I enter the following details into the form:
+      | email | <value> |
+    And I click on 'Send reset email'
+    Then I should see the following error messages:
+      | Enter your email address in the correct format, like name@example.com |
+
+    Examples:
+      | value           |
+      |                 |
+      | fake@email      |
+      | fake email      |
+
+  Scenario: I forgot my password - user not found
+    And I cannot reset my password becaue of the 'user not found' error
+    Then I am on the 'Reset your password' page
+
+  Scenario Outline: I forgot my password - cognito error
+    And I cannot reset my password becaue of the '<error>' error
+    Then I should see the following error messages:
+      | <error_message> |
+    
+    Examples:
+      | error             | error_message                                                         |
+      | invalid parameter | Enter your email address in the correct format, like name@example.com |
+      | service           | An error occured: service                                             |

--- a/features/services/legal_services/rm6240/cognito/validations/sign_in_validation.feature
+++ b/features/services/legal_services/rm6240/cognito/validations/sign_in_validation.feature
@@ -1,0 +1,264 @@
+@pipeline
+Feature: Sign in to my account - Legal Services - RM6240 - Validations
+
+  Background: Navigate to the sign in page
+    When I go to the 'legal services' start page for 'RM6240'
+    Then I am on the 'Find legal services for the wider public sector' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your legal services account' page
+
+  Scenario: I sign in to my account - missing parameters
+    And I click on 'Sign in'
+    Then I should see the following error messages:
+      | You must provide your email address in the correct format, like name@example.com  |
+      | You must provide your password                                                    |
+
+  Scenario: I sign in to my account - cookies disabled
+    And my cookies are disabled
+    And I enter the following details into the form:
+      | Email     | test@email.com  |
+      | Password  | ValidPassword1! |
+    And I click on 'Sign in'
+    Then I should see the following error messages:
+      | Your browser must have cookies enabled  |
+
+  Scenario Outline: I sign in to my account - cognito error
+    And I cannot sign in becaue of the '<error>' error
+    Then I should see the following error messages:
+      | <error_message> |
+    
+    Examples:
+      | error           | error_message                                   |
+      | user not found  | You must provide a correct username or password |
+      | service         | You must provide a correct username or password |
+
+  Scenario Outline: I sign in with MFA - invalid code
+    Then I should sign in with MFA and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | <value> |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | value   | error_message                                     |
+      |         | Enter the access code                             |
+      | 123     | Access code must be 6 characters                  |
+      | 1234567 | Access code must be 6 characters                  |
+      | onetwo  | Access code must contain numeric characters only  |
+
+  Scenario: I sign in with MFA - service error
+    And I cannot sign in with MFA because of the 'service' error and I have the following roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456  |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | An error occured: service |
+
+  Scenario Outline:  I sign in for the first time - password errors
+    Then I should sign in for the first time with the roles:
+      | ls_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter '<password>' for the password
+    And I enter '<password>' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | password    | error_message                             |
+      | Pass!1      | Password must be 8 characters or more     |
+      | password1!  | Password must include a capital letter    |
+      | Password1   | Password must include a special character |
+      | Password!   | Password must include a number            |
+
+  Scenario: I sign in for the first time - passwords blank
+    Then I should sign in for the first time with the roles:
+      | ls_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter '' for the password
+    And I enter '' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | Enter a password    |
+      | Enter your password |
+
+  Scenario: I sign in for the first time - passwords don't match
+    Then I should sign in for the first time with the roles:
+      | ls_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter 'Password1!' for the password
+    And I enter 'ValidPassw0rd!' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | Passwords don't match |
+
+  Scenario: I sign in for the first time - service error
+    And I cannot sign in for the first time because of the 'service' error and I have the following roles:
+      | ls_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter 'ValidPassword1!' for the password
+    And I enter 'ValidPassword1!' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | An error occured: service |
+
+  Scenario Outline: I sign in for the first time with MFA - invalid code
+    Then I should sign in for the first time with MFA Enabled and with the roles:
+      | ls_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter the following details into the form:
+      | Create a password you'll remember | ValidPassword1! |
+      | Confirm your password             | ValidPassword1! |
+    And I click on 'Change password and sign in'
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | <value> |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | value   | error_message                                     |
+      |         | Enter the access code                             |
+      | 123     | Access code must be 6 characters                  |
+      | 1234567 | Access code must be 6 characters                  |
+      | onetwo  | Access code must contain numeric characters only  |
+
+  Scenario: I sign in for the first time - service error
+    And I cannot sign in for the first time with MFA Enabled because of the 'service' error and I have the following roles:
+      | ls_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter 'ValidPassword1!' for the password
+    And I enter 'ValidPassword1!' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456  |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | An error occured: service |
+
+  Scenario Outline: I sign in for the first time after creating an account - invalid code
+    Then I should sign in as user who just created their account and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Activate your account' page
+    And I enter the following details into the form:
+      | Confirmation code | <value> |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | value   | error_message                                           |
+      |         | Enter your verification code                            |
+      | 123     | Confirmation code must be 6 characters                  |
+      | 1234567 | Confirmation code must be 6 characters                  |
+      | onetwo  | Confirmation code must contain numeric characters only  |
+
+  Scenario Outline: I sign in for the first time after creating an account - cognito error
+    And I cannot sign in having just created my account because of the '<error>' error and I have the following roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Activate your account' page
+    And I enter the following details into the form:
+      | Confirmation code | 123456 |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | error           | error_message                                         |
+      | not authorized  | Invalid verification code provided, please try again  |
+      | service         | An error occured: service                             |
+
+  Scenario Outline: I sign in and need to reset my password - password error
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | <password>  |
+      | Confirm new password  | <password>  |
+      | Verification code     | 123456      |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | password    | error_message                             |
+      | Pass!1      | Password must be 8 characters or more     |
+      | password1!  | Password must include a capital letter    |
+      | Password1   | Password must include a special character |
+      | Password!   | Password must include a number            |
+
+  Scenario: I sign in and need to reset my password - passwords blank
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          |         |
+      | Confirm new password  |         |
+      | Verification code     | 123456  |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | Enter a password    |
+      | Enter your password |
+
+  Scenario: I sign in and need to reset my password - passwords don't match
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | Password1!      |
+      | Confirm new password  | ValidPassw0rd!  |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | Passwords don't match |
+
+  Scenario: I sign in and need to reset my password - code blank
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     |                 |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | Enter your verification code  |
+
+  Scenario Outline: I sign in and need to reset my password - cognito error
+    And I cannot sign in and reset my password because of the '<error>' error and I have the following roles:
+      | ls_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | error         | error_message                     |
+      | code mismatch |  An error occured: code mismatch  |
+      | service       | An error occured: service         |

--- a/features/services/legal_services/rm6240/cognito/validations/sign_up_user_validations.feature
+++ b/features/services/legal_services/rm6240/cognito/validations/sign_up_user_validations.feature
@@ -1,0 +1,71 @@
+@allow_list @pipeline
+Feature: Sign up user - Legal Services - RM6240 - Validations
+
+  Background: navigate to create an account page
+    When I go to the 'legal services' start page for 'RM6240'
+    Then I am on the 'Find legal services for the wider public sector' page
+    When I click on 'Start now'
+    Then I am on the 'Sign in to your legal services account' page
+    And I click on 'Create an account'
+    Then I am on the 'Create a CCS account' page
+
+  Scenario: Email validations
+    Given I enter '<email>' for my email
+    And I enter 'Passowrd1!' for the password
+    And I enter 'Passowrd1!' for the password confirmation
+    When I click on 'Create account'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | email         | error_message                                                       |
+      |               | Enter an email address in the correct format, like name@example.com |
+      | Test@test.com | Email address cannot contain any capital letters                    |
+
+  Scenario: Not on allow list
+    Given I enter 'test@tmail.com' for my email
+    And I enter 'Passowrd1!' for the password
+    And I enter 'Passowrd1!' for the password confirmation
+    When I click on 'Create account'
+    Then I am on the 'You must use a public sector email address' page
+
+  Scenario Outline: Password validations
+    Given I enter 'test@test.com' for my email
+    And I enter '<password>' for the password
+    And I enter '<password>' for the password confirmation
+    When I click on 'Create account'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | password    | error_message                             |
+      | Pass!1      | Password must be 8 characters or more     |
+      | password1!  | Password must include a capital letter    |
+      | Password1   | Password must include a special character |
+      | Password!   | Password must include a number            |
+
+  Scenario: Password blank
+    Given I enter 'test@test.com' for my email
+    And I enter '' for the password
+    And I enter '' for the password confirmation
+    When I click on 'Create account'
+    Then I should see the following error messages:
+      | Enter a password    |
+      | Enter your password |
+
+  Scenario: Password confirmation doesn't match
+    Given I enter 'test@test.com' for my email
+    And I enter 'Password1!' for the password
+    And I enter 'ValidPassw0rd!' for the password confirmation
+    When I click on 'Create account'
+    Then I should see the following error messages:
+      | Passwords don't match |
+
+  Scenario: Create an account - username exists error
+    And I cannot create an account becaue of the 'username exists' error
+    Then I am on the 'Activate your account' page
+
+  Scenario: Create an account - service error
+    And I cannot create an account becaue of the 'service' error
+    Then I should see the following error messages:
+      | An error occured: service |

--- a/features/services/legal_services/rm6240/home/cookie_settings.feature
+++ b/features/services/legal_services/rm6240/home/cookie_settings.feature
@@ -14,7 +14,7 @@ Feature: Legal Services - Cookie settings
     When I click on 'Accept analytics cookies'
     Then the cookie banner shows I have 'accepted' the cookies
     And I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     And the cookie banner 'is not' visible
     And the cookies have been saved
     And the 'ga' cookies have been 'accepted'
@@ -24,7 +24,7 @@ Feature: Legal Services - Cookie settings
     When I click on 'Reject analytics cookies'
     Then the cookie banner shows I have 'rejected' the cookies
     And I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     And the cookie banner 'is not' visible
     And the cookies have been saved
     And the 'ga' cookies have been 'rejected'

--- a/features/services/legal_services/rm6240/home/navigation_links/navigation_links_signed_out.feature
+++ b/features/services/legal_services/rm6240/home/navigation_links/navigation_links_signed_out.feature
@@ -14,7 +14,7 @@ Feature: Legal Services - Navigation links when signed out
 
   Scenario: Sign in page 
     And I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     And I should see the following navigation links:
       | Back to start |
     And I click on 'Back to start'

--- a/features/services/legal_services/rm6240/home/start_pages.feature
+++ b/features/services/legal_services/rm6240/home/start_pages.feature
@@ -9,12 +9,12 @@ Feature: Legal Services - Start pages
     When I go to the 'legal services' start page for 'RM6240'
     Then I am on the 'Find legal services for the wider public sector' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
 
   Scenario: Logging in
     When I go to the 'legal services' start page for 'RM6240'
     Then I am on the 'Find legal services for the wider public sector' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     Then I should sign in as an 'ls' buyer
     Then I am on the 'Do you work for central government?' page

--- a/features/services/legal_services/rm6240/home/validations/sign_up_user_validations.feature
+++ b/features/services/legal_services/rm6240/home/validations/sign_up_user_validations.feature
@@ -5,7 +5,7 @@ Feature: Legal Services - Sign up user
     Given I go to the 'legal services' start page for 'RM6240'
     And I am on the 'Find legal services for the wider public sector' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your legal services buyer account' page
+    Then I am on the 'Sign in to your legal services account' page
     And I click on 'Create an account'
     Then I am on the 'Create a CCS account' page
 
@@ -16,7 +16,7 @@ Feature: Legal Services - Sign up user
     When I click on 'Create account'
     Then I should see the following error messages:
       | <error_message> |
-    
+
     Examples:
       | email         | error_message                                                       |
       |               | Enter an email address in the correct format, like name@example.com |

--- a/features/services/management_consultancy/rm6187/cognito/forgot_password.feature
+++ b/features/services/management_consultancy/rm6187/cognito/forgot_password.feature
@@ -1,0 +1,22 @@
+@pipeline
+Feature: Forgot my password - Management Consultancy - RM6187
+
+  Scenario: I forgot my password
+    When I go to the 'management consultancy' start page for 'RM6187'
+    Then I am on the 'Find management consultants' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your management consultancy account' page
+    When I click on 'I’ve forgotten my password'
+    Then I am on the 'Reset password' page
+    And I can reset my password with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I am on the 'You have successfully changed your password' page
+    And I click on 'Sign in'
+    And I am on the 'Sign in to your management consultancy account' page

--- a/features/services/management_consultancy/rm6187/cognito/sign_in.feature
+++ b/features/services/management_consultancy/rm6187/cognito/sign_in.feature
@@ -1,0 +1,74 @@
+@pipeline
+Feature: Sign in to my account - Management Consultancy - RM6187
+
+  Background: Navigate to the sign in page
+    When I go to the 'management consultancy' start page for 'RM6187'
+    Then I am on the 'Find management consultants' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your management consultancy account' page
+
+  Scenario: I sign in to my existing account
+    Then I should sign in with the roles:
+      | mc_access |
+      | buyer     |
+    And I am on the 'Important changes to how you access Management Consultancy Framework Three' page
+
+  Scenario: I sign in with MFA
+    Then I should sign in with MFA and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456 |
+    And I click on 'Continue'
+    Then I am on the 'Important changes to how you access Management Consultancy Framework Three' page
+
+  Scenario: I sign in for the first time
+    Then I should sign in for the first time with the roles:
+      | mc_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter the following details into the form:
+      | Create a password you'll remember | ValidPassword1! |
+      | Confirm your password             | ValidPassword1! |
+    And I click on 'Change password and sign in'
+    Then I am on the 'Important changes to how you access Management Consultancy Framework Three' page
+
+  Scenario: I sign in for the first time with MFA
+    Then I should sign in for the first time with MFA Enabled and with the roles:
+      | mc_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter the following details into the form:
+      | Create a password you'll remember | ValidPassword1! |
+      | Confirm your password             | ValidPassword1! |
+    And I click on 'Change password and sign in'
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456 |
+    And I click on 'Continue'
+    Then I am on the 'Important changes to how you access Management Consultancy Framework Three' page
+
+  Scenario: I sign in for the first time after creating an account
+    Then I should sign in as user who just created their account and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Activate your account' page
+    And I enter the following details into the form:
+      | Confirmation code | 123456 |
+    And I click on 'Continue'
+    Then I am on the 'Important changes to how you access Management Consultancy Framework Three' page
+
+  Scenario: I sign in and need to reset my password
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I am on the 'You have successfully changed your password' page
+    And I click on 'Sign in'
+    And I am on the 'Sign in to your management consultancy account' page

--- a/features/services/management_consultancy/rm6187/cognito/sign_up_user.feature
+++ b/features/services/management_consultancy/rm6187/cognito/sign_up_user.feature
@@ -1,0 +1,16 @@
+@allow_list @pipeline
+Feature: Sign up to management consultancy - RM6187
+
+  Scenario: I sign in to my existing account
+    When I go to the 'management consultancy' start page for 'RM6187'
+    Then I am on the 'Find management consultants' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your management consultancy account' page
+    And I click on 'Create an account'
+    Then I am on the 'Create a CCS account' page
+    And I am able to create an 'mc' account
+    Then I am on the 'Activate your account' page
+    And I enter the following details into the form:
+      | Confirmation code | 123456 |
+    And I click on 'Continue'
+    Then I am on the 'Important changes to how you access Management Consultancy Framework Three' page

--- a/features/services/management_consultancy/rm6187/cognito/validations/forgot_password_validations.feature
+++ b/features/services/management_consultancy/rm6187/cognito/validations/forgot_password_validations.feature
@@ -1,0 +1,37 @@
+@pipeline
+Feature: Forgot my password - Management Consultancy - RM6187 - Validations
+
+  Background: Navigate to forgot password
+    When I go to the 'management consultancy' start page for 'RM6187'
+    Then I am on the 'Find management consultants' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your management consultancy account' page
+    When I click on 'I’ve forgotten my password'
+    Then I am on the 'Reset password' page
+
+  Scenario Outline: I forgot my password - email invalid
+    And I enter the following details into the form:
+      | email | <value> |
+    And I click on 'Send reset email'
+    Then I should see the following error messages:
+      | Enter your email address in the correct format, like name@example.com |
+
+    Examples:
+      | value           |
+      |                 |
+      | fake@email      |
+      | fake email      |
+
+  Scenario: I forgot my password - user not found
+    And I cannot reset my password becaue of the 'user not found' error
+    Then I am on the 'Reset your password' page
+
+  Scenario Outline: I forgot my password - cognito error
+    And I cannot reset my password becaue of the '<error>' error
+    Then I should see the following error messages:
+      | <error_message> |
+    
+    Examples:
+      | error             | error_message                                                         |
+      | invalid parameter | Enter your email address in the correct format, like name@example.com |
+      | service           | An error occured: service                                             |

--- a/features/services/management_consultancy/rm6187/cognito/validations/sign_in_validation.feature
+++ b/features/services/management_consultancy/rm6187/cognito/validations/sign_in_validation.feature
@@ -1,0 +1,264 @@
+@pipeline
+Feature: Sign in to my account - Management Consultancy - RM6187 - Validations
+
+  Background: Navigate to the sign in page
+    When I go to the 'management consultancy' start page for 'RM6187'
+    Then I am on the 'Find management consultants' page
+    When I click on 'Start now'
+    And I am on the 'Sign in to your management consultancy account' page
+
+  Scenario: I sign in to my account - missing parameters
+    And I click on 'Sign in'
+    Then I should see the following error messages:
+      | You must provide your email address in the correct format, like name@example.com  |
+      | You must provide your password                                                    |
+
+  Scenario: I sign in to my account - cookies disabled
+    And my cookies are disabled
+    And I enter the following details into the form:
+      | Email     | test@email.com  |
+      | Password  | ValidPassword1! |
+    And I click on 'Sign in'
+    Then I should see the following error messages:
+      | Your browser must have cookies enabled  |
+
+  Scenario Outline: I sign in to my account - cognito error
+    And I cannot sign in becaue of the '<error>' error
+    Then I should see the following error messages:
+      | <error_message> |
+    
+    Examples:
+      | error           | error_message                                   |
+      | user not found  | You must provide a correct username or password |
+      | service         | You must provide a correct username or password |
+
+  Scenario Outline: I sign in with MFA - invalid code
+    Then I should sign in with MFA and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | <value> |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | value   | error_message                                     |
+      |         | Enter the access code                             |
+      | 123     | Access code must be 6 characters                  |
+      | 1234567 | Access code must be 6 characters                  |
+      | onetwo  | Access code must contain numeric characters only  |
+
+  Scenario: I sign in with MFA - service error
+    And I cannot sign in with MFA because of the 'service' error and I have the following roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456  |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | An error occured: service |
+
+  Scenario Outline:  I sign in for the first time - password errors
+    Then I should sign in for the first time with the roles:
+      | mc_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter '<password>' for the password
+    And I enter '<password>' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | password    | error_message                             |
+      | Pass!1      | Password must be 8 characters or more     |
+      | password1!  | Password must include a capital letter    |
+      | Password1   | Password must include a special character |
+      | Password!   | Password must include a number            |
+
+  Scenario: I sign in for the first time - passwords blank
+    Then I should sign in for the first time with the roles:
+      | mc_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter '' for the password
+    And I enter '' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | Enter a password    |
+      | Enter your password |
+
+  Scenario: I sign in for the first time - passwords don't match
+    Then I should sign in for the first time with the roles:
+      | mc_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter 'Password1!' for the password
+    And I enter 'ValidPassw0rd!' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | Passwords don't match |
+
+  Scenario: I sign in for the first time - service error
+    And I cannot sign in for the first time because of the 'service' error and I have the following roles:
+      | mc_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter 'ValidPassword1!' for the password
+    And I enter 'ValidPassword1!' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | An error occured: service |
+
+  Scenario Outline: I sign in for the first time with MFA - invalid code
+    Then I should sign in for the first time with MFA Enabled and with the roles:
+      | mc_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter the following details into the form:
+      | Create a password you'll remember | ValidPassword1! |
+      | Confirm your password             | ValidPassword1! |
+    And I click on 'Change password and sign in'
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | <value> |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | value   | error_message                                     |
+      |         | Enter the access code                             |
+      | 123     | Access code must be 6 characters                  |
+      | 1234567 | Access code must be 6 characters                  |
+      | onetwo  | Access code must contain numeric characters only  |
+
+  Scenario: I sign in for the first time - service error
+    And I cannot sign in for the first time with MFA Enabled because of the 'service' error and I have the following roles:
+      | mc_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter 'ValidPassword1!' for the password
+    And I enter 'ValidPassword1!' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456  |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | An error occured: service |
+
+  Scenario Outline: I sign in for the first time after creating an account - invalid code
+    Then I should sign in as user who just created their account and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Activate your account' page
+    And I enter the following details into the form:
+      | Confirmation code | <value> |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | value   | error_message                                           |
+      |         | Enter your verification code                            |
+      | 123     | Confirmation code must be 6 characters                  |
+      | 1234567 | Confirmation code must be 6 characters                  |
+      | onetwo  | Confirmation code must contain numeric characters only  |
+
+  Scenario Outline: I sign in for the first time after creating an account - cognito error
+    And I cannot sign in having just created my account because of the '<error>' error and I have the following roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Activate your account' page
+    And I enter the following details into the form:
+      | Confirmation code | 123456 |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | error           | error_message                                         |
+      | not authorized  | Invalid verification code provided, please try again  |
+      | service         | An error occured: service                             |
+
+  Scenario Outline: I sign in and need to reset my password - password error
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | <password>  |
+      | Confirm new password  | <password>  |
+      | Verification code     | 123456      |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | password    | error_message                             |
+      | Pass!1      | Password must be 8 characters or more     |
+      | password1!  | Password must include a capital letter    |
+      | Password1   | Password must include a special character |
+      | Password!   | Password must include a number            |
+
+  Scenario: I sign in and need to reset my password - passwords blank
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          |         |
+      | Confirm new password  |         |
+      | Verification code     | 123456  |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | Enter a password    |
+      | Enter your password |
+
+  Scenario: I sign in and need to reset my password - passwords don't match
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | Password1!      |
+      | Confirm new password  | ValidPassw0rd!  |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | Passwords don't match |
+
+  Scenario: I sign in and need to reset my password - code blank
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     |                 |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | Enter your verification code  |
+
+  Scenario Outline: I sign in and need to reset my password - cognito error
+    And I cannot sign in and reset my password because of the '<error>' error and I have the following roles:
+      | mc_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | error         | error_message                     |
+      | code mismatch |  An error occured: code mismatch  |
+      | service       | An error occured: service         |

--- a/features/services/management_consultancy/rm6187/cognito/validations/sign_up_user_validations.feature
+++ b/features/services/management_consultancy/rm6187/cognito/validations/sign_up_user_validations.feature
@@ -1,0 +1,71 @@
+@allow_list @pipeline
+Feature: Sign up user - Management Consultancy - RM6187 - Validations
+
+  Background: navigate to create an account page
+    When I go to the 'management consultancy' start page for 'RM6187'
+    Then I am on the 'Find management consultants' page
+    When I click on 'Start now'
+    Then I am on the 'Sign in to your management consultancy account' page
+    And I click on 'Create an account'
+    Then I am on the 'Create a CCS account' page
+
+  Scenario: Email validations
+    Given I enter '<email>' for my email
+    And I enter 'Passowrd1!' for the password
+    And I enter 'Passowrd1!' for the password confirmation
+    When I click on 'Create account'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | email         | error_message                                                       |
+      |               | Enter an email address in the correct format, like name@example.com |
+      | Test@test.com | Email address cannot contain any capital letters                    |
+
+  Scenario: Not on allow list
+    Given I enter 'test@tmail.com' for my email
+    And I enter 'Passowrd1!' for the password
+    And I enter 'Passowrd1!' for the password confirmation
+    When I click on 'Create account'
+    Then I am on the 'You must use a public sector email address' page
+
+  Scenario Outline: Password validations
+    Given I enter 'test@test.com' for my email
+    And I enter '<password>' for the password
+    And I enter '<password>' for the password confirmation
+    When I click on 'Create account'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | password    | error_message                             |
+      | Pass!1      | Password must be 8 characters or more     |
+      | password1!  | Password must include a capital letter    |
+      | Password1   | Password must include a special character |
+      | Password!   | Password must include a number            |
+
+  Scenario: Password blank
+    Given I enter 'test@test.com' for my email
+    And I enter '' for the password
+    And I enter '' for the password confirmation
+    When I click on 'Create account'
+    Then I should see the following error messages:
+      | Enter a password    |
+      | Enter your password |
+
+  Scenario: Password confirmation doesn't match
+    Given I enter 'test@test.com' for my email
+    And I enter 'Password1!' for the password
+    And I enter 'ValidPassw0rd!' for the password confirmation
+    When I click on 'Create account'
+    Then I should see the following error messages:
+      | Passwords don't match |
+
+  Scenario: Create an account - username exists error
+    And I cannot create an account becaue of the 'username exists' error
+    Then I am on the 'Activate your account' page
+
+  Scenario: Create an account - service error
+    And I cannot create an account becaue of the 'service' error
+    Then I should see the following error messages:
+      | An error occured: service |

--- a/features/services/management_consultancy/rm6187/home/cookie_settings.feature
+++ b/features/services/management_consultancy/rm6187/home/cookie_settings.feature
@@ -14,7 +14,7 @@ Feature: Management Consultancy - Cookie settings
     When I click on 'Accept analytics cookies'
     Then the cookie banner shows I have 'accepted' the cookies
     And I click on 'Start now'
-    Then I am on the 'Sign in to your management consultancy buyer account' page
+    Then I am on the 'Sign in to your management consultancy account' page
     And the cookie banner 'is not' visible
     And the cookies have been saved
     And the 'ga' cookies have been 'accepted'
@@ -24,7 +24,7 @@ Feature: Management Consultancy - Cookie settings
     When I click on 'Reject analytics cookies'
     Then the cookie banner shows I have 'rejected' the cookies
     And I click on 'Start now'
-    Then I am on the 'Sign in to your management consultancy buyer account' page
+    Then I am on the 'Sign in to your management consultancy account' page
     And the cookie banner 'is not' visible
     And the cookies have been saved
     And the 'ga' cookies have been 'rejected'

--- a/features/services/management_consultancy/rm6187/home/navigation_links/navigation_links_signed_out.feature
+++ b/features/services/management_consultancy/rm6187/home/navigation_links/navigation_links_signed_out.feature
@@ -14,7 +14,7 @@ Feature: Management Consultancy - Navigation links when signed out
 
   Scenario: Sign in page 
     And I click on 'Start now'
-    Then I am on the 'Sign in to your management consultancy buyer account' page
+    Then I am on the 'Sign in to your management consultancy account' page
     And I should see the following navigation links:
       | Back to start |
     And I click on 'Back to start'

--- a/features/services/management_consultancy/rm6187/home/start_pages.feature
+++ b/features/services/management_consultancy/rm6187/home/start_pages.feature
@@ -9,12 +9,12 @@ Feature: Management Consultancy - Start pages
     When I go to the 'management consultancy' start page for 'RM6187'
     Then I am on the 'Find management consultants' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your management consultancy buyer account' page
+    Then I am on the 'Sign in to your management consultancy account' page
 
   Scenario: Logging in
     When I go to the 'management consultancy' start page for 'RM6187'
     Then I am on the 'Find management consultants' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your management consultancy buyer account' page
+    Then I am on the 'Sign in to your management consultancy account' page
     Then I should sign in as an 'mc' buyer
     Then I am on the 'Important changes to how you access Management Consultancy Framework Three' page

--- a/features/services/management_consultancy/rm6187/home/validations/sign_up_user_validations.feature
+++ b/features/services/management_consultancy/rm6187/home/validations/sign_up_user_validations.feature
@@ -5,7 +5,7 @@ Feature: Management Consultancy - Sign up user
     Given I go to the 'management consultancy' start page for 'RM6187'
     And I am on the 'Find management consultants' page
     When I click on 'Start now'
-    Then I am on the 'Sign in to your management consultancy buyer account' page
+    Then I am on the 'Sign in to your management consultancy account' page
     And I click on 'Create an account'
     Then I am on the 'Create a CCS account' page
 

--- a/features/services/supply_teachers/rm6238/cognito/forgot_password.feature
+++ b/features/services/supply_teachers/rm6238/cognito/forgot_password.feature
@@ -1,0 +1,24 @@
+@pipeline
+Feature: Forgot my password - Supply Teachers - RM6238
+
+  Scenario: I forgot my password
+    When I go to the 'supply teachers' start page for 'RM6238'
+    Then I am on the 'Find supply teachers and agency workers' page
+    When I click on 'Start now'
+    Then I am on the 'Sign in to find supply teachers and agency workers' page
+    And I click on 'Sign in with CCS'
+    And I am on the 'Sign in to your supply teachers account' page
+    When I click on 'I’ve forgotten my password'
+    Then I am on the 'Reset password' page
+    And I can reset my password with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I am on the 'You have successfully changed your password' page
+    And I click on 'Sign in'
+    And I am on the 'Sign in to find supply teachers and agency workers' page

--- a/features/services/supply_teachers/rm6238/cognito/sign_in.feature
+++ b/features/services/supply_teachers/rm6238/cognito/sign_in.feature
@@ -1,0 +1,66 @@
+@pipeline
+Feature: Sign in to my account - Supply Teachers - RM6238
+
+  Background: Navigate to the sign in page
+    When I go to the 'supply teachers' start page for 'RM6238'
+    Then I am on the 'Find supply teachers and agency workers' page
+    When I click on 'Start now'
+    Then I am on the 'Sign in to find supply teachers and agency workers' page
+    And I click on 'Sign in with CCS'
+    And I am on the 'Sign in to your supply teachers account' page
+
+  Scenario: I sign in to my existing account
+    Then I should sign in with the roles:
+      | st_access |
+      | buyer     |
+    And I am on the 'What is your school looking for?' page
+
+  Scenario: I sign in with MFA
+    Then I should sign in with MFA and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456 |
+    And I click on 'Continue'
+    Then I am on the 'What is your school looking for?' page
+
+  Scenario: I sign in for the first time
+    Then I should sign in for the first time with the roles:
+      | st_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter the following details into the form:
+      | Create a password you'll remember | ValidPassword1! |
+      | Confirm your password             | ValidPassword1! |
+    And I click on 'Change password and sign in'
+    Then I am on the 'What is your school looking for?' page
+
+  Scenario: I sign in for the first time with MFA
+    Then I should sign in for the first time with MFA Enabled and with the roles:
+      | st_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter the following details into the form:
+      | Create a password you'll remember | ValidPassword1! |
+      | Confirm your password             | ValidPassword1! |
+    And I click on 'Change password and sign in'
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456 |
+    And I click on 'Continue'
+    Then I am on the 'What is your school looking for?' page
+
+  Scenario: I sign in and need to reset my password
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I am on the 'You have successfully changed your password' page
+    And I click on 'Sign in'
+    And I am on the 'Sign in to find supply teachers and agency workers' page

--- a/features/services/supply_teachers/rm6238/cognito/validations/forgot_password_validations.feature
+++ b/features/services/supply_teachers/rm6238/cognito/validations/forgot_password_validations.feature
@@ -1,0 +1,39 @@
+@pipeline
+Feature: Forgot my password - Supply Teachers - RM6238 - Validations
+
+  Background: Navigate to forgot password
+    When I go to the 'supply teachers' start page for 'RM6238'
+    Then I am on the 'Find supply teachers and agency workers' page
+    When I click on 'Start now'
+    Then I am on the 'Sign in to find supply teachers and agency workers' page
+    And I click on 'Sign in with CCS'
+    And I am on the 'Sign in to your supply teachers account' page
+    When I click on 'I’ve forgotten my password'
+    Then I am on the 'Reset password' page
+
+  Scenario Outline: I forgot my password - email invalid
+    And I enter the following details into the form:
+      | email | <value> |
+    And I click on 'Send reset email'
+    Then I should see the following error messages:
+      | Enter your email address in the correct format, like name@example.com |
+
+    Examples:
+      | value           |
+      |                 |
+      | fake@email      |
+      | fake email      |
+
+  Scenario: I forgot my password - user not found
+    And I cannot reset my password becaue of the 'user not found' error
+    Then I am on the 'Reset your password' page
+
+  Scenario Outline: I forgot my password - cognito error
+    And I cannot reset my password becaue of the '<error>' error
+    Then I should see the following error messages:
+      | <error_message> |
+    
+    Examples:
+      | error             | error_message                                                         |
+      | invalid parameter | Enter your email address in the correct format, like name@example.com |
+      | service           | An error occured: service                                             |

--- a/features/services/supply_teachers/rm6238/cognito/validations/sign_in_validation.feature
+++ b/features/services/supply_teachers/rm6238/cognito/validations/sign_in_validation.feature
@@ -1,0 +1,266 @@
+@pipeline
+Feature: Sign in to my account - Supply Teachers - RM6238 - Validations
+
+  Background: Navigate to the sign in page
+    When I go to the 'supply teachers' start page for 'RM6238'
+    Then I am on the 'Find supply teachers and agency workers' page
+    When I click on 'Start now'
+    Then I am on the 'Sign in to find supply teachers and agency workers' page
+    And I click on 'Sign in with CCS'
+    And I am on the 'Sign in to your supply teachers account' page
+
+  Scenario: I sign in to my account - missing parameters
+    And I click on 'Sign in'
+    Then I should see the following error messages:
+      | You must provide your email address in the correct format, like name@example.com  |
+      | You must provide your password                                                    |
+
+  Scenario: I sign in to my account - cookies disabled
+    And my cookies are disabled
+    And I enter the following details into the form:
+      | Email     | test@email.com  |
+      | Password  | ValidPassword1! |
+    And I click on 'Sign in'
+    Then I should see the following error messages:
+      | Your browser must have cookies enabled  |
+
+  Scenario Outline: I sign in to my account - cognito error
+    And I cannot sign in becaue of the '<error>' error
+    Then I should see the following error messages:
+      | <error_message> |
+    
+    Examples:
+      | error           | error_message                                   |
+      | user not found  | You must provide a correct username or password |
+      | service         | You must provide a correct username or password |
+
+  Scenario Outline: I sign in with MFA - invalid code
+    Then I should sign in with MFA and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | <value> |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | value   | error_message                                     |
+      |         | Enter the access code                             |
+      | 123     | Access code must be 6 characters                  |
+      | 1234567 | Access code must be 6 characters                  |
+      | onetwo  | Access code must contain numeric characters only  |
+
+  Scenario: I sign in with MFA - service error
+    And I cannot sign in with MFA because of the 'service' error and I have the following roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456  |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | An error occured: service |
+
+  Scenario Outline:  I sign in for the first time - password errors
+    Then I should sign in for the first time with the roles:
+      | st_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter '<password>' for the password
+    And I enter '<password>' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | password    | error_message                             |
+      | Pass!1      | Password must be 8 characters or more     |
+      | password1!  | Password must include a capital letter    |
+      | Password1   | Password must include a special character |
+      | Password!   | Password must include a number            |
+
+  Scenario: I sign in for the first time - passwords blank
+    Then I should sign in for the first time with the roles:
+      | st_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter '' for the password
+    And I enter '' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | Enter a password    |
+      | Enter your password |
+
+  Scenario: I sign in for the first time - passwords don't match
+    Then I should sign in for the first time with the roles:
+      | st_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter 'Password1!' for the password
+    And I enter 'ValidPassw0rd!' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | Passwords don't match |
+
+  Scenario: I sign in for the first time - service error
+    And I cannot sign in for the first time because of the 'service' error and I have the following roles:
+      | st_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter 'ValidPassword1!' for the password
+    And I enter 'ValidPassword1!' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I should see the following error messages:
+      | An error occured: service |
+
+  Scenario Outline: I sign in for the first time with MFA - invalid code
+    Then I should sign in for the first time with MFA Enabled and with the roles:
+      | st_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter the following details into the form:
+      | Create a password you'll remember | ValidPassword1! |
+      | Confirm your password             | ValidPassword1! |
+    And I click on 'Change password and sign in'
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | <value> |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | value   | error_message                                     |
+      |         | Enter the access code                             |
+      | 123     | Access code must be 6 characters                  |
+      | 1234567 | Access code must be 6 characters                  |
+      | onetwo  | Access code must contain numeric characters only  |
+
+  Scenario: I sign in for the first time - service error
+    And I cannot sign in for the first time with MFA Enabled because of the 'service' error and I have the following roles:
+      | st_access |
+      | buyer     |
+    And I am on the 'Change your password' page
+    And I enter 'ValidPassword1!' for the password
+    And I enter 'ValidPassword1!' for the password confirmation
+    And I click on 'Change password and sign in'
+    Then I am on the 'Enter your access code' page
+    And I enter the following details into the form:
+      | Access code | 123456  |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | An error occured: service |
+
+  Scenario Outline: I sign in for the first time after creating an account - invalid code
+    Then I should sign in as user who just created their account and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Activate your account' page
+    And I enter the following details into the form:
+      | Confirmation code | <value> |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | value   | error_message                                           |
+      |         | Enter your verification code                            |
+      | 123     | Confirmation code must be 6 characters                  |
+      | 1234567 | Confirmation code must be 6 characters                  |
+      | onetwo  | Confirmation code must contain numeric characters only  |
+
+  Scenario Outline: I sign in for the first time after creating an account - cognito error
+    And I cannot sign in having just created my account because of the '<error>' error and I have the following roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Activate your account' page
+    And I enter the following details into the form:
+      | Confirmation code | 123456 |
+    And I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | error           | error_message                                         |
+      | not authorized  | Invalid verification code provided, please try again  |
+      | service         | An error occured: service                             |
+
+  Scenario Outline: I sign in and need to reset my password - password error
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | <password>  |
+      | Confirm new password  | <password>  |
+      | Verification code     | 123456      |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | password    | error_message                             |
+      | Pass!1      | Password must be 8 characters or more     |
+      | password1!  | Password must include a capital letter    |
+      | Password1   | Password must include a special character |
+      | Password!   | Password must include a number            |
+
+  Scenario: I sign in and need to reset my password - passwords blank
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          |         |
+      | Confirm new password  |         |
+      | Verification code     | 123456  |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | Enter a password    |
+      | Enter your password |
+
+  Scenario: I sign in and need to reset my password - passwords don't match
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | Password1!      |
+      | Confirm new password  | ValidPassw0rd!  |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | Passwords don't match |
+
+  Scenario: I sign in and need to reset my password - code blank
+    Then I should sign in as a user who needs to reset their password and with the roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     |                 |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | Enter your verification code  |
+
+  Scenario Outline: I sign in and need to reset my password - cognito error
+    And I cannot sign in and reset my password because of the '<error>' error and I have the following roles:
+      | st_access |
+      | buyer     |
+    Then I am on the 'Reset your password' page
+    And I enter the following details into the form:
+      | New password          | ValidPassword1! |
+      | Confirm new password  | ValidPassword1! |
+      | Verification code     | 123456          |
+    And I click on 'Reset password'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | error         | error_message                     |
+      | code mismatch |  An error occured: code mismatch  |
+      | service       | An error occured: service         |

--- a/features/step_definitions/cognito_steps.rb
+++ b/features/step_definitions/cognito_steps.rb
@@ -1,0 +1,108 @@
+Then 'I sign in with cognito' do
+  update_banner_cookie(true) if @javascript
+  fill_in 'email', with: @user_email
+  fill_in 'password', with: 'ValidPassword'
+  click_on 'Sign in'
+end
+
+Then 'I create an account with cognito' do
+  update_banner_cookie(true) if @javascript
+  fill_in 'Email address', with: @user_email
+  fill_in "Create a password you'll remember", with: 'ValidPassword1!'
+  fill_in 'Confirm your password', with: 'ValidPassword1!'
+  click_on 'Create account'
+end
+
+Then 'I reset my password with cognito' do
+  update_banner_cookie(true) if @javascript
+  fill_in 'Email address', with: @user_email
+  click_on 'Send reset email'
+end
+
+When('my cookies are disabled') do
+  if @javascript
+    page.driver.browser.manage.delete_all_cookies
+  else
+    page.driver.browser.clear_cookies
+  end
+end
+
+Then('I should sign in with the roles:') do |roles|
+  stub_cognito(:existing_user, roles.raw.flatten)
+  step 'I sign in with cognito'
+end
+
+Then('I should sign in with MFA and with the roles:') do |roles|
+  stub_cognito(:sms_mfa, roles.raw.flatten)
+  step 'I sign in with cognito'
+end
+
+Then('I should sign in for the first time with the roles:') do |roles|
+  stub_cognito(:first_time_password_reset, roles.raw.flatten)
+  step 'I sign in with cognito'
+end
+
+Then('I should sign in for the first time with MFA Enabled and with the roles:') do |roles|
+  stub_cognito(:first_time_sms_mfa, roles.raw.flatten)
+  step 'I sign in with cognito'
+end
+
+Then('I should sign in as user who just created their account and with the roles:') do |roles|
+  stub_cognito(:first_time_confirm_account, roles.raw.flatten)
+  step 'I sign in with cognito'
+end
+
+Then('I should sign in as a user who needs to reset their password and with the roles:') do |roles|
+  stub_cognito(:password_reset_required, roles.raw.flatten)
+  step 'I sign in with cognito'
+end
+
+Then('I can reset my password with the roles:') do |roles|
+  stub_cognito(:forgot_password, roles.raw.flatten)
+  step 'I reset my password with cognito'
+end
+
+Then('I am able to create an {string} account') do |service|
+  stub_cognito(:create_an_account, ["#{service}_access", 'buyer'])
+  step 'I create an account with cognito'
+end
+
+Then('I cannot reset my password becaue of the {string} error') do |error_key|
+  stub_cognito_with_error(:forgot_password, error_key)
+  step 'I reset my password with cognito'
+end
+
+Then('I cannot create an account becaue of the {string} error') do |error_key|
+  stub_cognito_with_error(:create_an_account, error_key)
+  step 'I create an account with cognito'
+end
+
+When('I cannot sign in becaue of the {string} error') do |error_key|
+  stub_cognito_with_error(:sign_in, error_key)
+  step 'I sign in with cognito'
+end
+
+When('I cannot sign in with MFA because of the {string} error and I have the following roles:') do |error_key, roles|
+  stub_cognito_with_error(:sms_mfa, error_key, roles.raw.flatten)
+  step 'I sign in with cognito'
+end
+
+When('I cannot sign in for the first time because of the {string} error and I have the following roles:') do |error_key, roles|
+  stub_cognito_with_error(:first_time_password_reset, error_key, roles.raw.flatten)
+  step 'I sign in with cognito'
+end
+
+When('I cannot sign in for the first time with MFA Enabled because of the {string} error and I have the following roles:') do |error_key, roles|
+  stub_cognito_with_error(:first_time_sms_mfa, error_key, roles.raw.flatten)
+  step 'I sign in with cognito'
+end
+
+When('I cannot sign in having just created my account because of the {string} error and I have the following roles:') do |error_key, roles|
+  stub_cognito_with_error(:first_time_confirm_account, error_key, roles.raw.flatten)
+  step 'I sign in with cognito'
+end
+
+When('I cannot sign in and reset my password because of the {string} error and I have the following roles:') do |error_key, roles|
+  stub_cognito_with_error(:password_reset_required, error_key, roles.raw.flatten)
+  step 'I sign in with cognito'
+end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -129,6 +129,12 @@ Then('I should see the following error messages:') do |table|
   expect(page.find('.govuk-error-summary__list').find_all('a').map(&:text).reject(&:empty?)).to eq table.raw.flatten
 end
 
+Then('I enter the following details into the form:') do |table|
+  table.raw.to_h.each do |field, value|
+    fill_in field, with: value
+  end
+end
+
 Given('I select {string}') do |item|
   choose item
 end

--- a/spec/controllers/legal_services/rm3788/admin/users_controller_spec.rb
+++ b/spec/controllers/legal_services/rm3788/admin/users_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe LegalServices::RM3788::Admin::UsersController, type: :controller 
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/spec/controllers/legal_services/rm3788/users_controller_spec.rb
+++ b/spec/controllers/legal_services/rm3788/users_controller_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe LegalServices::RM3788::UsersController, type: :controller do
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/spec/controllers/legal_services/rm6240/admin/users_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/admin/users_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe LegalServices::RM6240::Admin::UsersController, type: :controller 
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/spec/controllers/legal_services/rm6240/users_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/users_controller_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe LegalServices::RM6240::UsersController, type: :controller do
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/spec/controllers/management_consultancy/rm6187/admin/users_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/admin/users_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::UsersController, type: :con
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/spec/controllers/management_consultancy/rm6187/users_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/users_controller_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe ManagementConsultancy::RM6187::UsersController, type: :controller
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/spec/controllers/supply_teachers/rm3826/admin/users_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm3826/admin/users_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SupplyTeachers::RM3826::Admin::UsersController, type: :controller
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/spec/controllers/supply_teachers/rm3826/users_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm3826/users_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SupplyTeachers::RM3826::UsersController, type: :controller do
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/spec/controllers/supply_teachers/rm6238/admin/users_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/admin/users_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SupplyTeachers::RM6238::Admin::UsersController, type: :controller
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/spec/controllers/supply_teachers/rm6238/users_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/users_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SupplyTeachers::RM6238::UsersController, type: :controller do
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }

--- a/spec/features/authentication.feature_spec.rb
+++ b/spec/features/authentication.feature_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Authentication', type: :feature do
     OmniAuth.config.test_mode = false
     visit '/management-consultancy/RM6187/start'
 
-    expect(page).to have_text('Sign in to your management consultancy buyer account')
+    expect(page).to have_text('Sign in to your management consultancy account')
   end
 
   scenario 'Users can sign in using AWS Cognito' do
@@ -59,7 +59,7 @@ RSpec.feature 'Authentication', type: :feature do
     click_on 'Sign out'
 
     visit '/management-consultancy/RM6187/start'
-    expect(page).to have_text('Sign in to your management consultancy buyer account')
+    expect(page).to have_text('Sign in to your management consultancy account')
   end
 
   scenario 'Users can sign in using DfE sign-in', dfe: true do

--- a/spec/services/cognito/respond_to_challenge_spec.rb
+++ b/spec/services/cognito/respond_to_challenge_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Cognito::RespondToChallenge do
 
     before do
       allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-      allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+      allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
       allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(true)
     end
 
@@ -63,7 +63,7 @@ RSpec.describe Cognito::RespondToChallenge do
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(true)
       end
 
@@ -94,7 +94,7 @@ RSpec.describe Cognito::RespondToChallenge do
 
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session))
       end
 
       it 'returns success' do


### PR DESCRIPTION
Ticket: [FMFR-1320](https://crowncommercialservice.atlassian.net/browse/FMFR-1320)

There is a bug when logging on for the first time with MFA enabled. Because the service was not set up properly, the actual response received from cognito was not accounted for and so one of the parameters needed to log in was lost.

In this commit I have applied a code change which will fix this issue.

In addition, I have bitten the bullet somewhat and created feature tests for logging in so that we have better coverage of this area of the application. I have also added accessibility tests too.