### PR TITLE
FMFR-1333 - Fix issue with migration in Release 2.5.3

### DIFF
--- a/db/migrate/20220929130611_fix_issue_with_ls_uploads.rb
+++ b/db/migrate/20220929130611_fix_issue_with_ls_uploads.rb
@@ -1,24 +1,25 @@
 class FixIssueWithLsUploads < ActiveRecord::Migration[6.0]
+  # We have to turn off this migration due to an issue in Legacy Release 2.5.3
   def up
-    ActiveStorage::Attachment.where(record_type: 'LegalServices::Admin::Upload').find_in_batches do |attachment_group|
-      sleep(5)
+    # ActiveStorage::Attachment.where(record_type: 'LegalServices::Admin::Upload').find_in_batches do |attachment_group|
+    #   sleep(5)
 
-      attachment_group.each do |attachment|
-        new_record_type = ''
+    #   attachment_group.each do |attachment|
+    #     new_record_type = ''
 
-        if LegalServices::RM3788::Admin::Upload.find_by(id: attachment.record_id)
-          new_record_type = 'LegalServices::RM3788::Admin::Upload'
-        elsif LegalServices::RM6240::Admin::Upload.find_by(id: attachment.record_id)
-          new_record_type = 'LegalServices::RM6240::Admin::Upload'
-        else
-          Rails.logger.warn("Could not find LegalServices::Admin::Upload for #{attachment.record_id}")
+    #     if LegalServices::RM3788::Admin::Upload.find_by(id: attachment.record_id)
+    #       new_record_type = 'LegalServices::RM3788::Admin::Upload'
+    #     elsif LegalServices::RM6240::Admin::Upload.find_by(id: attachment.record_id)
+    #       new_record_type = 'LegalServices::RM6240::Admin::Upload'
+    #     else
+    #       Rails.logger.warn("Could not find LegalServices::Admin::Upload for #{attachment.record_id}")
 
-          next
-        end
+    #       next
+    #     end
 
-        attachment.update(record_type: new_record_type)
-      end
-    end
+    #     attachment.update(record_type: new_record_type)
+    #   end
+    # end
   end
 
   def down; end

--- a/db/migrate/20221024121403_remove_unused_file_columns.rb
+++ b/db/migrate/20221024121403_remove_unused_file_columns.rb
@@ -1,7 +1,7 @@
 class RemoveUnusedFileColumns < ActiveRecord::Migration[6.1]
   def change
-    remove_column :management_consultancy_rm6187_admin_uploads, :supplier_details_file, type: :string, limit: 255
-    remove_column :management_consultancy_rm6187_admin_uploads, :supplier_rate_cards_file, type: :string, limit: 255
-    remove_column :management_consultancy_rm6187_admin_uploads, :supplier_service_offerings_file, type: :string, limit: 255
+    remove_column :management_consultancy_rm6187_admin_uploads, :supplier_details_file, :string, limit: 255
+    remove_column :management_consultancy_rm6187_admin_uploads, :supplier_rate_cards_file, :string, limit: 255
+    remove_column :management_consultancy_rm6187_admin_uploads, :supplier_service_offerings_file, :string, limit: 255
   end
 end

--- a/db/migrate/20221104103710_fix_issue_with_ls_uploads_again.rb
+++ b/db/migrate/20221104103710_fix_issue_with_ls_uploads_again.rb
@@ -1,0 +1,27 @@
+class FixIssueWithLsUploadsAgain < ActiveRecord::Migration[6.1]
+  class LsRM6240AdminUpload < ApplicationRecord
+    self.table_name = 'legal_services_rm6240_admin_uploads'
+  end
+
+  def up
+    ActiveStorage::Attachment.where(record_type: 'LegalServices::Admin::Upload').find_in_batches do |attachment_group|
+      sleep(5)
+
+      attachment_group.each do |attachment|
+        new_record_type = ''
+
+        if LsRM6240AdminUpload.find_by(id: attachment.record_id)
+          new_record_type = 'LegalServices::RM6240::Admin::Upload'
+        else
+          Rails.logger.warn("Could not find LegalServices::Admin::Upload for #{attachment.record_id}")
+
+          next
+        end
+
+        attachment.update(record_type: new_record_type)
+      end
+    end
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_24_122658) do
+ActiveRecord::Schema.define(version: 2022_11_04_103710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
Ticket: [FMFR-1333](https://crowncommercialservice.atlassian.net/browse/FMFR-1333)

Due to an issue with the [legacy release 2.5.3](https://github.com/Crown-Commercial-Service/crown-marketplace-legacy/pull/470), the database migration did not work due to models being removed. This has meant the admin sections for MC, LS and ST are not working.

I have had to comment out the original migration as that will no longer work both due to the model being removed and an update to rails. I have then added a new migration which will fix the issue with the LS upload for real this time.

I have tested it locally and it works, we will not be able to test this in the lower environments.