### PR TITLE
FMFR-1357 - Port changes from FM to allow validation of frameworks during authentication

### DIFF
--- a/app/controllers/concerns/legal_services/admin/framework_status_concern.rb
+++ b/app/controllers/concerns/legal_services/admin/framework_status_concern.rb
@@ -1,0 +1,20 @@
+module LegalServices::Admin::FrameworkStatusConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :raise_if_unrecognised_framework
+
+    rescue_from ApplicationController::UnrecognisedFrameworkError do
+      @unrecognised_framework = params[:framework]
+      params[:framework] = Framework.legal_services.current_framework
+
+      render 'legal_services/admin/home/unrecognised_framework', status: :bad_request
+    end
+  end
+
+  protected
+
+  def raise_if_unrecognised_framework
+    raise ApplicationController::UnrecognisedFrameworkError, 'Unrecognised Framework' unless Framework.legal_services.recognised_framework? params[:framework]
+  end
+end

--- a/app/controllers/concerns/legal_services/framework_status_concern.rb
+++ b/app/controllers/concerns/legal_services/framework_status_concern.rb
@@ -1,0 +1,20 @@
+module LegalServices::FrameworkStatusConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :raise_if_not_live_framework
+
+    rescue_from ApplicationController::UnrecognisedLiveFrameworkError do
+      @unrecognised_framework = params[:framework]
+      params[:framework] = Framework.legal_services.current_framework
+
+      render 'legal_services/home/unrecognised_framework', status: :bad_request
+    end
+  end
+
+  protected
+
+  def raise_if_not_live_framework
+    raise ApplicationController::UnrecognisedLiveFrameworkError, 'Unrecognised Live Framework' unless Framework.legal_services.live_framework?(params[:framework])
+  end
+end

--- a/app/controllers/concerns/management_consultancy/admin/framework_status_concern.rb
+++ b/app/controllers/concerns/management_consultancy/admin/framework_status_concern.rb
@@ -1,0 +1,20 @@
+module ManagementConsultancy::Admin::FrameworkStatusConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :raise_if_unrecognised_framework
+
+    rescue_from ApplicationController::UnrecognisedFrameworkError do
+      @unrecognised_framework = params[:framework]
+      params[:framework] = Framework.management_consultancy.current_framework
+
+      render 'management_consultancy/admin/home/unrecognised_framework', status: :bad_request
+    end
+  end
+
+  protected
+
+  def raise_if_unrecognised_framework
+    raise ApplicationController::UnrecognisedFrameworkError, 'Unrecognised Framework' unless Framework.management_consultancy.recognised_framework? params[:framework]
+  end
+end

--- a/app/controllers/concerns/management_consultancy/framework_status_concern.rb
+++ b/app/controllers/concerns/management_consultancy/framework_status_concern.rb
@@ -1,0 +1,20 @@
+module ManagementConsultancy::FrameworkStatusConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :raise_if_not_live_framework
+
+    rescue_from ApplicationController::UnrecognisedLiveFrameworkError do
+      @unrecognised_framework = params[:framework]
+      params[:framework] = Framework.management_consultancy.current_framework
+
+      render 'management_consultancy/home/unrecognised_framework', status: :bad_request
+    end
+  end
+
+  protected
+
+  def raise_if_not_live_framework
+    raise ApplicationController::UnrecognisedLiveFrameworkError, 'Unrecognised Live Framework' unless Framework.management_consultancy.live_framework?(params[:framework])
+  end
+end

--- a/app/controllers/concerns/supply_teachers/admin/framework_status_concern.rb
+++ b/app/controllers/concerns/supply_teachers/admin/framework_status_concern.rb
@@ -1,0 +1,20 @@
+module SupplyTeachers::Admin::FrameworkStatusConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :raise_if_unrecognised_framework
+
+    rescue_from ApplicationController::UnrecognisedFrameworkError do
+      @unrecognised_framework = params[:framework]
+      params[:framework] = Framework.supply_teachers.current_framework
+
+      render 'supply_teachers/admin/home/unrecognised_framework', status: :bad_request
+    end
+  end
+
+  protected
+
+  def raise_if_unrecognised_framework
+    raise ApplicationController::UnrecognisedFrameworkError, 'Unrecognised Framework' unless Framework.supply_teachers.recognised_framework? params[:framework]
+  end
+end

--- a/app/controllers/concerns/supply_teachers/framework_status_concern.rb
+++ b/app/controllers/concerns/supply_teachers/framework_status_concern.rb
@@ -1,0 +1,20 @@
+module SupplyTeachers::FrameworkStatusConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :raise_if_not_live_framework
+
+    rescue_from ApplicationController::UnrecognisedLiveFrameworkError do
+      @unrecognised_framework = params[:framework]
+      params[:framework] = Framework.supply_teachers.current_framework
+
+      render 'supply_teachers/home/unrecognised_framework', status: :bad_request
+    end
+  end
+
+  protected
+
+  def raise_if_not_live_framework
+    raise ApplicationController::UnrecognisedLiveFrameworkError, 'Unrecognised Live Framework' unless Framework.supply_teachers.live_framework?(params[:framework])
+  end
+end

--- a/app/controllers/legal_services/admin/framework_controller.rb
+++ b/app/controllers/legal_services/admin/framework_controller.rb
@@ -1,16 +1,10 @@
 module LegalServices
   module Admin
     class FrameworkController < ::ApplicationController
+      include FrameworkStatusConcern
+
       before_action :authenticate_user!
       before_action :authorize_user
-      before_action :raise_if_unrecognised_framework
-
-      rescue_from UnrecognisedFrameworkError do
-        @unrecognised_framework = params[:framework]
-        params[:framework] = Framework.legal_services.current_framework
-
-        render 'legal_services/admin/home/unrecognised_framework', status: :bad_request
-      end
 
       protected
 
@@ -20,10 +14,6 @@ module LegalServices
 
       def service_scope
         :legal_services
-      end
-
-      def raise_if_unrecognised_framework
-        raise UnrecognisedFrameworkError, 'Unrecognised Framework' unless Framework.legal_services.recognised_framework? params[:framework]
       end
     end
   end

--- a/app/controllers/legal_services/framework_controller.rb
+++ b/app/controllers/legal_services/framework_controller.rb
@@ -1,24 +1,14 @@
 module LegalServices
   class FrameworkController < ::ApplicationController
-    before_action :raise_if_not_live_framework
+    include FrameworkStatusConcern
+
     before_action :authenticate_user!
     before_action :authorize_user
-
-    rescue_from UnrecognisedLiveFrameworkError do
-      @unrecognised_framework = params[:framework]
-      params[:framework] = Framework.legal_services.current_framework
-
-      render 'legal_services/home/unrecognised_framework', status: :bad_request
-    end
 
     protected
 
     def authorize_user
       authorize! :read, LegalServices
-    end
-
-    def raise_if_not_live_framework
-      raise UnrecognisedLiveFrameworkError, 'Unrecognised Live Framework' unless Framework.legal_services.live_framework?(params[:framework])
     end
   end
 end

--- a/app/controllers/legal_services/rm6240/admin/passwords_controller.rb
+++ b/app/controllers/legal_services/rm6240/admin/passwords_controller.rb
@@ -2,6 +2,7 @@ module LegalServices
   module RM6240
     module Admin
       class PasswordsController < Base::PasswordsController
+        include LegalServices::Admin::FrameworkStatusConcern
       end
     end
   end

--- a/app/controllers/legal_services/rm6240/admin/sessions_controller.rb
+++ b/app/controllers/legal_services/rm6240/admin/sessions_controller.rb
@@ -2,6 +2,7 @@ module LegalServices
   module RM6240
     module Admin
       class SessionsController < Base::SessionsController
+        include LegalServices::Admin::FrameworkStatusConcern
       end
     end
   end

--- a/app/controllers/legal_services/rm6240/admin/users_controller.rb
+++ b/app/controllers/legal_services/rm6240/admin/users_controller.rb
@@ -2,6 +2,7 @@ module LegalServices
   module RM6240
     module Admin
       class UsersController < Base::UsersController
+        include LegalServices::Admin::FrameworkStatusConcern
       end
     end
   end

--- a/app/controllers/legal_services/rm6240/passwords_controller.rb
+++ b/app/controllers/legal_services/rm6240/passwords_controller.rb
@@ -1,6 +1,7 @@
 module LegalServices
   module RM6240
     class PasswordsController < Base::PasswordsController
+      include LegalServices::FrameworkStatusConcern
     end
   end
 end

--- a/app/controllers/legal_services/rm6240/registrations_controller.rb
+++ b/app/controllers/legal_services/rm6240/registrations_controller.rb
@@ -1,6 +1,8 @@
 module LegalServices
   module RM6240
     class RegistrationsController < Base::RegistrationsController
+      include LegalServices::FrameworkStatusConcern
+
       private
 
       def ls_access

--- a/app/controllers/legal_services/rm6240/sessions_controller.rb
+++ b/app/controllers/legal_services/rm6240/sessions_controller.rb
@@ -1,6 +1,7 @@
 module LegalServices
   module RM6240
     class SessionsController < Base::SessionsController
+      include LegalServices::FrameworkStatusConcern
     end
   end
 end

--- a/app/controllers/legal_services/rm6240/users_controller.rb
+++ b/app/controllers/legal_services/rm6240/users_controller.rb
@@ -1,6 +1,7 @@
 module LegalServices
   module RM6240
     class UsersController < Base::UsersController
+      include LegalServices::FrameworkStatusConcern
     end
   end
 end

--- a/app/controllers/management_consultancy/admin/framework_controller.rb
+++ b/app/controllers/management_consultancy/admin/framework_controller.rb
@@ -1,16 +1,10 @@
 module ManagementConsultancy
   module Admin
     class FrameworkController < ::ApplicationController
+      include FrameworkStatusConcern
+
       before_action :authenticate_user!
       before_action :authorize_user
-      before_action :raise_if_unrecognised_framework
-
-      rescue_from UnrecognisedFrameworkError do
-        @unrecognised_framework = params[:framework]
-        params[:framework] = Framework.management_consultancy.current_framework
-
-        render 'management_consultancy/admin/home/unrecognised_framework', status: :bad_request
-      end
 
       protected
 
@@ -20,10 +14,6 @@ module ManagementConsultancy
 
       def service_scope
         :management_consultancy
-      end
-
-      def raise_if_unrecognised_framework
-        raise UnrecognisedFrameworkError, 'Unrecognised Framework' unless Framework.management_consultancy.recognised_framework? params[:framework]
       end
     end
   end

--- a/app/controllers/management_consultancy/framework_controller.rb
+++ b/app/controllers/management_consultancy/framework_controller.rb
@@ -1,24 +1,14 @@
 module ManagementConsultancy
   class FrameworkController < ::ApplicationController
-    before_action :raise_if_not_live_framework
+    include FrameworkStatusConcern
+
     before_action :authenticate_user!
     before_action :authorize_user
-
-    rescue_from UnrecognisedLiveFrameworkError do
-      @unrecognised_framework = params[:framework]
-      params[:framework] = Framework.management_consultancy.current_framework
-
-      render 'management_consultancy/home/unrecognised_framework', status: :bad_request
-    end
 
     protected
 
     def authorize_user
       authorize! :read, ManagementConsultancy
-    end
-
-    def raise_if_not_live_framework
-      raise UnrecognisedLiveFrameworkError, 'Unrecognised Live Framework' unless Framework.management_consultancy.live_framework?(params[:framework])
     end
   end
 end

--- a/app/controllers/management_consultancy/rm6187/admin/passwords_controller.rb
+++ b/app/controllers/management_consultancy/rm6187/admin/passwords_controller.rb
@@ -2,6 +2,7 @@ module ManagementConsultancy
   module RM6187
     module Admin
       class PasswordsController < Base::PasswordsController
+        include ManagementConsultancy::Admin::FrameworkStatusConcern
       end
     end
   end

--- a/app/controllers/management_consultancy/rm6187/admin/sessions_controller.rb
+++ b/app/controllers/management_consultancy/rm6187/admin/sessions_controller.rb
@@ -2,6 +2,7 @@ module ManagementConsultancy
   module RM6187
     module Admin
       class SessionsController < Base::SessionsController
+        include ManagementConsultancy::Admin::FrameworkStatusConcern
       end
     end
   end

--- a/app/controllers/management_consultancy/rm6187/admin/users_controller.rb
+++ b/app/controllers/management_consultancy/rm6187/admin/users_controller.rb
@@ -2,6 +2,7 @@ module ManagementConsultancy
   module RM6187
     module Admin
       class UsersController < Base::UsersController
+        include ManagementConsultancy::Admin::FrameworkStatusConcern
       end
     end
   end

--- a/app/controllers/management_consultancy/rm6187/passwords_controller.rb
+++ b/app/controllers/management_consultancy/rm6187/passwords_controller.rb
@@ -1,6 +1,7 @@
 module ManagementConsultancy
   module RM6187
     class PasswordsController < Base::PasswordsController
+      include ManagementConsultancy::FrameworkStatusConcern
     end
   end
 end

--- a/app/controllers/management_consultancy/rm6187/registrations_controller.rb
+++ b/app/controllers/management_consultancy/rm6187/registrations_controller.rb
@@ -1,6 +1,8 @@
 module ManagementConsultancy
   module RM6187
     class RegistrationsController < Base::RegistrationsController
+      include ManagementConsultancy::FrameworkStatusConcern
+
       private
 
       def mc_access

--- a/app/controllers/management_consultancy/rm6187/sessions_controller.rb
+++ b/app/controllers/management_consultancy/rm6187/sessions_controller.rb
@@ -1,6 +1,7 @@
 module ManagementConsultancy
   module RM6187
     class SessionsController < Base::SessionsController
+      include ManagementConsultancy::FrameworkStatusConcern
     end
   end
 end

--- a/app/controllers/management_consultancy/rm6187/users_controller.rb
+++ b/app/controllers/management_consultancy/rm6187/users_controller.rb
@@ -1,6 +1,7 @@
 module ManagementConsultancy
   module RM6187
     class UsersController < Base::UsersController
+      include ManagementConsultancy::FrameworkStatusConcern
     end
   end
 end

--- a/app/controllers/supply_teachers/admin/framework_controller.rb
+++ b/app/controllers/supply_teachers/admin/framework_controller.rb
@@ -1,16 +1,10 @@
 module SupplyTeachers
   module Admin
     class FrameworkController < ::ApplicationController
+      include FrameworkStatusConcern
+
       before_action :authenticate_user!
       before_action :authorize_user
-      before_action :raise_if_unrecognised_framework
-
-      rescue_from UnrecognisedFrameworkError do
-        @unrecognised_framework = params[:framework]
-        params[:framework] = Framework.supply_teachers.current_framework
-
-        render 'supply_teachers/admin/home/unrecognised_framework', status: :bad_request
-      end
 
       protected
 
@@ -20,10 +14,6 @@ module SupplyTeachers
 
       def service_scope
         :supply_teachers
-      end
-
-      def raise_if_unrecognised_framework
-        raise UnrecognisedFrameworkError, 'Unrecognised Framework' unless Framework.supply_teachers.recognised_framework? params[:framework]
       end
     end
   end

--- a/app/controllers/supply_teachers/framework_controller.rb
+++ b/app/controllers/supply_teachers/framework_controller.rb
@@ -1,24 +1,14 @@
 module SupplyTeachers
   class FrameworkController < ::ApplicationController
-    before_action :raise_if_not_live_framework
+    include FrameworkStatusConcern
+
     before_action :authenticate_user!
     before_action :authorize_user
-
-    rescue_from UnrecognisedLiveFrameworkError do
-      @unrecognised_framework = params[:framework]
-      params[:framework] = Framework.supply_teachers.current_framework
-
-      render 'supply_teachers/home/unrecognised_framework', status: :bad_request
-    end
 
     protected
 
     def authorize_user
       authorize! :read, SupplyTeachers
-    end
-
-    def raise_if_not_live_framework
-      raise UnrecognisedLiveFrameworkError, 'Unrecognised Live Framework' unless Framework.supply_teachers.live_framework?(params[:framework])
     end
   end
 end

--- a/app/controllers/supply_teachers/rm6238/admin/passwords_controller.rb
+++ b/app/controllers/supply_teachers/rm6238/admin/passwords_controller.rb
@@ -2,6 +2,7 @@ module SupplyTeachers
   module RM6238
     module Admin
       class PasswordsController < Base::PasswordsController
+        include SupplyTeachers::Admin::FrameworkStatusConcern
       end
     end
   end

--- a/app/controllers/supply_teachers/rm6238/admin/sessions_controller.rb
+++ b/app/controllers/supply_teachers/rm6238/admin/sessions_controller.rb
@@ -2,6 +2,7 @@ module SupplyTeachers
   module RM6238
     module Admin
       class SessionsController < Base::SessionsController
+        include SupplyTeachers::Admin::FrameworkStatusConcern
       end
     end
   end

--- a/app/controllers/supply_teachers/rm6238/admin/users_controller.rb
+++ b/app/controllers/supply_teachers/rm6238/admin/users_controller.rb
@@ -2,6 +2,7 @@ module SupplyTeachers
   module RM6238
     module Admin
       class UsersController < Base::UsersController
+        include SupplyTeachers::Admin::FrameworkStatusConcern
       end
     end
   end

--- a/app/controllers/supply_teachers/rm6238/passwords_controller.rb
+++ b/app/controllers/supply_teachers/rm6238/passwords_controller.rb
@@ -1,6 +1,7 @@
 module SupplyTeachers
   module RM6238
     class PasswordsController < Base::PasswordsController
+      include SupplyTeachers::FrameworkStatusConcern
     end
   end
 end

--- a/app/controllers/supply_teachers/rm6238/sessions_controller.rb
+++ b/app/controllers/supply_teachers/rm6238/sessions_controller.rb
@@ -1,6 +1,7 @@
 module SupplyTeachers
   module RM6238
     class SessionsController < Base::SessionsController
+      include SupplyTeachers::FrameworkStatusConcern
     end
   end
 end

--- a/app/controllers/supply_teachers/rm6238/users_controller.rb
+++ b/app/controllers/supply_teachers/rm6238/users_controller.rb
@@ -1,6 +1,7 @@
 module SupplyTeachers
   module RM6238
     class UsersController < Base::UsersController
+      include SupplyTeachers::FrameworkStatusConcern
     end
   end
 end

--- a/data/spec_templates/passwords_controller_spec.txt
+++ b/data/spec_templates/passwords_controller_spec.txt
@@ -8,98 +8,179 @@ RSpec.describe <module_service_name>::PasswordsController do
   let(:default_params) { { service: '<service_param_name>', framework: '<FRAMEWORK>' } }
 
   describe 'GET new' do
-    before { get :new }
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-    render_views
+        expect(response).to render_template(:new)
+      end
+    end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:new)
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+
+<non_admin_only>
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
+</non_admin_only>
+<admin_only>
+      it 'renders the new page' do
+        get :new
+
+        expect(response).to render_template(:new)
+      end
+</admin_only>
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
-    context 'when no exception is raised' do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    context 'when the framework is live' do
+      context 'when no exception is raised' do
+        before do
+          post :create, params: { email: email }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the email is invalid' do
+          let(:email) { 'testtest.com' }
+
+          it 'redirects to the <service_name>_<framework><admin>_new_user_password_path' do
+            expect(response).to redirect_to <service_name>_<framework><admin>_new_user_password_path
+          end
+
+          it 'does not set the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to be_nil
+          end
+        end
+
+        context 'when the email is valid' do
+          let(:email) { 'test@test.com' }
+
+          it 'redirects to <service_name>_<framework><admin>_edit_user_password_path' do
+            expect(response).to redirect_to <service_name>_<framework><admin>_edit_user_password_path
+          end
+
+          it 'sets the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+          end
+        end
+      end
+
+      context 'when the email is valid but an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { email: 'test@test.com' }
+        end
+
+        context 'and the error is UserNotFoundException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
+
+          it 'redirects to the edit password page' do
+            expect(response).to redirect_to <service_name>_<framework><admin>_edit_user_password_path
+          end
+        end
+
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to <service_name>_<framework><admin>_new_user_password_path
+          end
+        end
+
+        context 'and the error is ServiceError' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to <service_name>_<framework><admin>_new_user_password_path
+          end
+        end
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+
+<non_admin_only>
+      it 'renders the unrecognised framework page with the right http status' do
+        post :create, params: { email: 'test@test.com' }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
+</non_admin_only>
+<admin_only>
       before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: email }
+        post :create, params: { email: 'test@test.com' }
         cookies.update(response.cookies)
       end
 
-      context 'when the email is invalid' do
-        let(:email) { 'testtest.com' }
-
-        it 'redirects to the <service_name>_<framework><admin>_new_user_password_path' do
-          expect(response).to redirect_to <service_name>_<framework><admin>_new_user_password_path
-        end
-
-        it 'does not set the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to be_nil
-        end
+      it 'redirects to <service_name>_<framework><admin>_edit_user_password_path' do
+        expect(response).to redirect_to <service_name>_<framework><admin>_edit_user_password_path
       end
 
-      context 'when the email is valid' do
-        let(:email) { 'test@test.com' }
-
-        it 'redirects to <service_name>_<framework><admin>_edit_user_password_path' do
-          expect(response).to redirect_to <service_name>_<framework><admin>_edit_user_password_path
-        end
-
-        it 'sets the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
-        end
+      it 'sets the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
       end
-    end
-
-    context 'when the email is valid but an exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: 'test@test.com' }
-      end
-
-      context 'and the error is UserNotFoundException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
-
-        it 'redirects to the edit password page' do
-          expect(response).to redirect_to <service_name>_<framework><admin>_edit_user_password_path
-        end
-      end
-
-      context 'and the error is InvalidParameterException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to <service_name>_<framework><admin>_new_user_password_path
-        end
-      end
-
-      context 'and the error is ServiceError' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to <service_name>_<framework><admin>_new_user_password_path
-        end
-      end
+</admin_only>
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET edit' do
-    before do
-      cookies[:crown_marketplace_reset_email] = 'test@email.com'
-      get :edit
+    context 'when the framework is live' do
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
     end
 
-    render_views
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
 
-    it 'renders the edit page' do
-      expect(response).to render_template(:edit)
-    end
+<non_admin_only>
+      it 'renders the unrecognised framework page with the right http status' do
+        get :edit
 
-    it 'the email has been set correctly in the response object' do
-      expect(assigns(:response).email).to eq('test@email.com')
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
+</non_admin_only>
+<admin_only>
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
+</admin_only>
     end
   end
 
@@ -110,24 +191,55 @@ RSpec.describe <module_service_name>::PasswordsController do
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
       # rubocop:enable RSpec/AnyInstance
-      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
-      cookies.update(response.cookies)
     end
 
-    context 'when the reset password is invalid' do
-      let(:password) { 'Pas12!' }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+    context 'when the framework is live' do
+      before do
+        put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+        cookies.update(response.cookies)
       end
 
-      it 'does not delete the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      context 'when the reset password is invalid' do
+        let(:password) { 'Pas12!' }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'does not delete the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+        end
+      end
+
+      context 'when the reset password is valid' do
+        let(:password) { 'Password12345!' }
+
+        it 'redirects to <service_name>_<framework><admin>_password_reset_success_path' do
+          expect(response).to redirect_to <service_name>_<framework><admin>_password_reset_success_path
+        end
+
+        it 'deletes the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to be_nil
+        end
       end
     end
 
-    context 'when the reset password is valid' do
-      let(:password) { 'Password12345!' }
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+
+<non_admin_only>
+      it 'renders the unrecognised framework page with the right http status' do
+        put :update, params: { email: 'test@test.com', password: 'Password12345!', password_confirmation: 'Password12345', confirmation_code: '123456' }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
+</non_admin_only>
+<admin_only>
+      before do
+        put :update, params: { email: 'test@test.com', password: 'Password12345!', password_confirmation: 'Password12345!', confirmation_code: '123456' }
+        cookies.update(response.cookies)
+      end
 
       it 'redirects to <service_name>_<framework><admin>_password_reset_success_path' do
         expect(response).to redirect_to <service_name>_<framework><admin>_password_reset_success_path
@@ -136,16 +248,37 @@ RSpec.describe <module_service_name>::PasswordsController do
       it 'deletes the crown_marketplace_reset_email cookie' do
         expect(cookies[:crown_marketplace_reset_email]).to be_nil
       end
+</admin_only>
     end
   end
 
   describe 'GET password_reset_success' do
-    before { get :password_reset_success }
+    context 'when the framework is live' do
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
 
-    render_views
+        expect(response).to render_template(:password_reset_success)
+      end
+    end
 
-    it 'renders the password_reset_success page' do
-      expect(response).to render_template(:password_reset_success)
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+
+<non_admin_only>
+      it 'renders the unrecognised framework page with the right http status' do
+        get :password_reset_success
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
+</non_admin_only>
+<admin_only>
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
+
+        expect(response).to render_template(:password_reset_success)
+      end
+</admin_only>
     end
   end
 end

--- a/data/spec_templates/registrations_controller_spec.txt
+++ b/data/spec_templates/registrations_controller_spec.txt
@@ -10,102 +10,139 @@ RSpec.describe <module_service_name>::RegistrationsController do
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'GET new' do
-    before { get :new }
+    context 'when the framework is live' do
+      before { get :new }
 
-    render_views
+      it 'renders the new page' do
+        expect(response).to render_template(:new)
+      end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:new)
+      it 'gives the user the buyer and <service_code>_access roles' do
+        expect(assigns(:result).roles).to eq(%i[buyer <service_code>_access])
+      end
     end
 
-    it 'gives the user the buyer and <service_code>_access roles' do
-      expect(assigns(:result).roles).to eq(%i[buyer <service_code>_access])
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
     let(:email) { 'test@testemail.com' }
     let(:password) { 'Password890!' }
     let(:password_confirmation) { password }
 
-    context 'when no exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_return({ user_sub: '1234567890' })
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
-        allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
-        cookies.update(response.cookies)
-      end
+    context 'when the framework is live' do
+      context 'when no exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_return({ user_sub: '1234567890' })
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
+          allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          cookies.update(response.cookies)
+        end
 
-      context 'when the emaildomain is not on the allow list' do
-        let(:email) { 'test@fake-testemail.com' }
+        context 'when the emaildomain is not on the allow list' do
+          let(:email) { 'test@fake-testemail.com' }
 
-        it 'redirects to <service_name>_<framework>_domain_not_on_safelist_path' do
-          expect(response).to redirect_to <service_name>_<framework>_domain_not_on_safelist_path
+          it 'redirects to <service_name>_<framework>_domain_not_on_safelist_path' do
+            expect(response).to redirect_to <service_name>_<framework>_domain_not_on_safelist_path
+          end
+        end
+
+        context 'when some of the information is invalid' do
+          let(:password_confirmation) { 'I do not match the password' }
+
+          it 'renders the new page' do
+            expect(response).to render_template(:new)
+          end
+        end
+
+        context 'when all the information is valid' do
+          it 'redirects to <service_name>_<framework>_users_confirm_path' do
+            expect(response).to redirect_to <service_name>_<framework>_users_confirm_path
+          end
+
+          it 'sets the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+          end
         end
       end
 
-      context 'when some of the information is invalid' do
-        let(:password_confirmation) { 'I do not match the password' }
-
-        it 'renders the new page' do
-          expect(response).to render_template(:new)
-        end
-      end
-
-      context 'when all the information is valid' do
-        it 'redirects to <service_name>_<framework>_users_confirm_path' do
-          expect(response).to redirect_to <service_name>_<framework>_users_confirm_path
+      context 'when an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_raise(error.new('Some context', 'Some message'))
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
+          allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          cookies.update(response.cookies)
         end
 
-        it 'sets the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+        context 'and the error is UsernameExistsException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UsernameExistsException }
+
+          it 'redirects to <service_name>_<framework>_users_confirm_path' do
+            expect(response).to redirect_to <service_name>_<framework>_users_confirm_path
+          end
+
+          it 'sets the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+          end
+        end
+
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'renders the new page' do
+            expect(response).to render_template(:new)
+          end
         end
       end
     end
 
-    context 'when an exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_raise(error.new('Some context', 'Some message'))
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
-        allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
-        # rubocop:enable RSpec/AnyInstance
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
         post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
-        cookies.update(response.cookies)
-      end
 
-      context 'and the error is UsernameExistsException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::UsernameExistsException }
-
-        it 'redirects to <service_name>_<framework>_users_confirm_path' do
-          expect(response).to redirect_to <service_name>_<framework>_users_confirm_path
-        end
-
-        it 'sets the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq email
-        end
-      end
-
-      context 'and the error is InvalidParameterException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
-
-        it 'renders the new page' do
-          expect(response).to render_template(:new)
-        end
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET domain_not_on_safelist' do
-    before { get :domain_not_on_safelist }
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :domain_not_on_safelist
 
-    render_views
+        expect(response).to render_template(:domain_not_on_safelist)
+      end
+    end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:domain_not_on_safelist)
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :domain_not_on_safelist
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 end

--- a/data/spec_templates/sessions_controller_spec.txt
+++ b/data/spec_templates/sessions_controller_spec.txt
@@ -10,10 +10,32 @@ RSpec.describe <module_service_name>::SessionsController do
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'GET new' do
-    it 'renders the new page' do
-      get :new
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-      expect(response).to render_template(:new)
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+
+<non_admin_only>
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
+</non_admin_only>
+<admin_only>
+      it 'renders the new page' do
+        get :new
+
+        expect(response).to render_template(:new)
+      end
+</admin_only>
     end
   end
 
@@ -115,6 +137,46 @@ RSpec.describe <module_service_name>::SessionsController do
           expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
         end
       end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+<non_admin_only>
+
+      it 'renders the unrecognised framework page with the right http status' do
+        post :create, params: { user: { email: email, password: 'Password12345!' } }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
+</non_admin_only>
+<admin_only>
+      include_context 'with cognito structs'
+
+      let(:username) { user.cognito_uuid }
+      let(:session) { 'I_AM_THE_SESSION' }
+      let(:cognito_groups) do
+        admin_list_groups_for_user_resp_struct.new(
+          groups: [
+            cognito_group_struct.new(group_name: '<role>'),
+            cognito_group_struct.new(group_name: '<service_code>_access')
+          ]
+        )
+      end
+
+      before do
+        allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: nil, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+
+        post :create, params: { user: { email: email, password: 'Password12345!' } }
+        cookies.update(response.cookies)
+      end
+
+      it 'redirects to <start_path>' do
+        expect(response).to redirect_to <start_path>
+      end
+</admin_only>
     end
   end
 

--- a/data/spec_templates/users_controller_spec.txt
+++ b/data/spec_templates/users_controller_spec.txt
@@ -8,12 +8,23 @@ RSpec.describe <module_service_name>::UsersController do
   let(:default_params) { { service: '<service_param_name>', framework: '<FRAMEWORK>' } }
 <registration_only>
   describe 'GET confirm_new' do
-    before { get :confirm_new }
+    context 'when the framework is live' do
+      it 'renders the confirm_new page' do
+        get :confirm_new
 
-    render_views
+        expect(response).to render_template(:confirm_new)
+      end
+    end
 
-    it 'renders the confirm_new page' do
-      expect(response).to render_template(:confirm_new)
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :confirm_new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
@@ -22,71 +33,86 @@ RSpec.describe <module_service_name>::UsersController do
     let(:user_email) { user.email }
     let(:confirmation_code) { '123456' }
 
-    context 'and there is no exception' do
-      before do
-        cookies[:crown_marketplace_confirmation_email] = user_email
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
-        cookies.update(response.cookies)
+    # rubocop:disable RSpec/NestedGroups
+    context 'when the framework is live' do
+      context 'and there is no exception' do
+        before do
+          cookies[:crown_marketplace_confirmation_email] = user_email
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_return(true)
+          # rubocop:enable RSpec/AnyInstance
+          post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the information is invalid' do
+          let(:confirmation_code) { '' }
+
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
+        end
+
+        context 'when the information is valid' do
+          it 'redirects to <start_path>' do
+            expect(response).to redirect_to <start_path>
+          end
+
+          it 'deletes the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to be_nil
+          end
+        end
       end
 
-      context 'when the information is invalid' do
-        let(:confirmation_code) { '' }
-
-        it 'renders confirm_new' do
-          expect(response).to render_template(:confirm_new)
+      context 'and there is an exception' do
+        before do
+          cookies[:crown_marketplace_confirmation_email] = user_email
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
-        end
-      end
+        context 'when the exception is generic' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
 
-      context 'when the information is valid' do
-        it 'redirects to <start_path>' do
-          expect(response).to redirect_to <start_path>
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
         end
 
-        it 'deletes the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to be_nil
+        context 'when the exception is NotAuthorizedException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::NotAuthorizedException }
+
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
         end
       end
     end
+    # rubocop:enable RSpec/NestedGroups
 
-    context 'and there is an exception' do
-      before do
-        cookies[:crown_marketplace_confirmation_email] = user_email
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_raise(error.new('Some context', 'Some message'))
-        # rubocop:enable RSpec/AnyInstance
-        post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
-        cookies.update(response.cookies)
-      end
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
 
-      context 'when the exception is generic' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+      it 'renders the unrecognised framework page with the right http status' do
+        post :confirm, params: { email: user_email, confirmation_code: '123456' }
 
-        it 'renders confirm_new' do
-          expect(response).to render_template(:confirm_new)
-        end
-
-        it 'does not delete the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
-        end
-      end
-
-      context 'when the exception is NotAuthorizedException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::NotAuthorizedException }
-
-        it 'renders confirm_new' do
-          expect(response).to render_template(:confirm_new)
-        end
-
-        it 'does not delete the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
-        end
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -94,40 +120,88 @@ RSpec.describe <module_service_name>::UsersController do
   describe 'POST resend_confirmation_email' do
     let(:email) { 'test@testemail.com' }
 
-    before do
-      allow(Cognito::ResendConfirmationCode).to receive(:call).with(email).and_return(Cognito::ResendConfirmationCode.new(email))
-      post :resend_confirmation_email, params: { email: email }
+    context 'when the framework is live' do
+      before do
+        allow(Cognito::ResendConfirmationCode).to receive(:call).with(email).and_return(Cognito::ResendConfirmationCode.new(email))
+        post :resend_confirmation_email, params: { email: email }
+      end
+
+      it 'redirects to <service_name>_<framework><admin>_users_confirm_path' do
+        expect(response).to redirect_to <service_name>_<framework><admin>_users_confirm_path
+      end
     end
 
-    it 'redirects to <service_name>_<framework><admin>_users_confirm_path' do
-      expect(response).to redirect_to <service_name>_<framework><admin>_users_confirm_path
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        post :resend_confirmation_email, params: { email: email }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 </registration_only>
   describe 'GET challenge_new' do
     let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
 
-    before do
-      cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
-      get :challenge_new, params: { challenge_name: challenge_name }
-    end
+    before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
-    render_views
+    context 'when the framework is live' do
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
 
-    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
-      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+      render_views
 
-      it 'renders the new_password_required partial' do
-        expect(response).to render_template(partial: 'base/users/_new_password_required')
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
       end
     end
 
-    context 'when the challenge is SMS_MFA' do
-      let(:challenge_name) { 'SMS_MFA' }
+    context 'when the framework is not live' do
+      include_context 'and <FRAMEWORK> has expired'
 
-      it 'renders the sms_mfa partial' do
-        expect(response).to render_template(partial: 'base/users/_sms_mfa')
+<non_admin_only>
+      it 'renders the unrecognised framework page with the right http status' do
+        get :challenge_new, params: { challenge_name: 'NEW_PASSWORD_REQUIRED' }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
+</non_admin_only>
+<admin_only>
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
+
+      render_views
+
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
+      end
+</admin_only>
     end
   end
 
@@ -155,48 +229,80 @@ RSpec.describe <module_service_name>::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:password) { 'Pas12!' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
-        end
-      end
+        context 'and it is not valid' do
+          let(:password) { 'Pas12!' }
 
-      context 'and it is valid' do
-        context 'and there is an additional challange' do
-          let(:new_challenge_name) { 'SMS_MFA' }
-
-          it 'redirects to <service_name>_<framework><admin>_users_challenge_path' do
-            expect(response).to redirect_to <service_name>_<framework><admin>_users_challenge_path(challenge_name: new_challenge_name)
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
           end
 
-          it 'the cookies are updated correctly' do
-            expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
             expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
           end
         end
 
-        context 'and there is no additional challange' do
-          it 'redirects to <start_path>' do
-            expect(response).to redirect_to <start_path>
+        context 'and it is valid' do
+          context 'and there is an additional challange' do
+            let(:new_challenge_name) { 'SMS_MFA' }
+
+            it 'redirects to <service_name>_<framework><admin>_users_challenge_path' do
+              expect(response).to redirect_to <service_name>_<framework><admin>_users_challenge_path(challenge_name: new_challenge_name)
+            end
+
+            it 'the cookies are updated correctly' do
+              expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+              expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+            end
           end
 
-          it 'deletes the cookies' do
-            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
-            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          context 'and there is no additional challange' do
+            it 'redirects to <start_path>' do
+              expect(response).to redirect_to <start_path>
+            end
+
+            it 'deletes the cookies' do
+              expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+              expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+            end
           end
         end
+      end
+
+      context 'when the framework is not live' do
+        include_context 'and <FRAMEWORK> has expired'
+
+<non_admin_only>
+        it 'renders the unrecognised framework page with the right http status' do
+          post :challenge, params: { challenge_name: 'SMS_MFA', username: username, session: session }
+
+          expect(response).to render_template('home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
+        end
+</non_admin_only>
+<admin_only>
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
+        end
+
+        it 'redirects to <start_path>' do
+          expect(response).to redirect_to <start_path>
+        end
+
+        it 'deletes the cookies' do
+          expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+          expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+        end
+</admin_only>
       end
     end
 
@@ -209,25 +315,56 @@ RSpec.describe <module_service_name>::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:access_code) { '123' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        context 'and it is not valid' do
+          let(:access_code) { '123' }
+
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
+          end
+
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+            expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+          end
+        end
+
+        context 'and it is valid' do
+          it 'redirects to <start_path>' do
+            expect(response).to redirect_to <start_path>
+          end
+
+          it 'deletes the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          end
         end
       end
 
-      context 'and it is valid' do
+      context 'when the framework is not live' do
+        include_context 'and <FRAMEWORK> has expired'
+
+<non_admin_only>
+        it 'renders the unrecognised framework page with the right http status' do
+          post :challenge, params: { challenge_name: 'SMS_MFA', username: username, session: session }
+
+          expect(response).to render_template('home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
+        end
+</non_admin_only>
+<admin_only>
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
+        end
+
         it 'redirects to <start_path>' do
           expect(response).to redirect_to <start_path>
         end
@@ -236,6 +373,7 @@ RSpec.describe <module_service_name>::UsersController do
           expect(cookies[:crown_marketplace_challenge_session]).to be_nil
           expect(cookies[:crown_marketplace_challenge_username]).to be_nil
         end
+</admin_only>
       end
     end
   end

--- a/lib/tasks/generate_authentication_specs.rake
+++ b/lib/tasks/generate_authentication_specs.rake
@@ -33,7 +33,7 @@ module GenerateAuthenticationSpecs
     base_tag_to_value.merge((admin ? admin_tag_to_value(service_name, framework) : buyer_tag_to_value(service_name, framework)))
   end
 
-  def self.generate_spec_file(output_file_path, source_file_path, tag_to_value, registration)
+  def self.generate_spec_file(output_file_path, source_file_path, tag_to_value, registration, admin)
     source_file_text = File.read(source_file_path)
 
     tag_to_value.each do |key, value|
@@ -45,6 +45,16 @@ module GenerateAuthenticationSpecs
       source_file_text.gsub!('</registration_only>', '')
     else
       source_file_text.gsub!(REGISTRATION_ONLY_REGEX, '')
+    end
+
+    if admin
+      source_file_text.gsub!("<admin_only>\n", '')
+      source_file_text.gsub!("</admin_only>\n", '')
+      source_file_text.gsub!(NON_ADMIN_ONLY_REGEX, '')
+    else
+      source_file_text.gsub!("<non_admin_only>\n", '')
+      source_file_text.gsub!("</non_admin_only>\n", '')
+      source_file_text.gsub!(ADMIN_ONLY_REGEX, '')
     end
 
     File.write(output_file_path, source_file_text)
@@ -96,10 +106,12 @@ module GenerateAuthenticationSpecs
 
     tag_to_value = generate_tag_to_value(service_name, framework, admin)
 
-    generate_spec_file(output_file_path, source_file_path, tag_to_value, service_and_framework[:registration])
+    generate_spec_file(output_file_path, source_file_path, tag_to_value, service_and_framework[:registration], service_and_framework[:admin])
   end
 
   REGISTRATION_ONLY_REGEX = %r{<registration_only>(.|\n)*?</registration_only>}.freeze
+  ADMIN_ONLY_REGEX = %r{<admin_only>(.|\n)*?</admin_only>\n}.freeze
+  NON_ADMIN_ONLY_REGEX = %r{<non_admin_only>(.|\n)*?</non_admin_only>\n}.freeze
 
   SERVICE_AND_FRAMEWORKS = [
     {

--- a/spec/controllers/legal_services/rm6240/admin/passwords_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/admin/passwords_controller_spec.rb
@@ -8,98 +8,149 @@ RSpec.describe LegalServices::RM6240::Admin::PasswordsController do
   let(:default_params) { { service: 'legal_services/admin', framework: 'RM6240' } }
 
   describe 'GET new' do
-    before { get :new }
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-    render_views
+        expect(response).to render_template(:new)
+      end
+    end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:new)
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the new page' do
+        get :new
+
+        expect(response).to render_template(:new)
+      end
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
-    context 'when no exception is raised' do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    context 'when the framework is live' do
+      context 'when no exception is raised' do
+        before do
+          post :create, params: { email: email }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the email is invalid' do
+          let(:email) { 'testtest.com' }
+
+          it 'redirects to the legal_services_rm6240_admin_new_user_password_path' do
+            expect(response).to redirect_to legal_services_rm6240_admin_new_user_password_path
+          end
+
+          it 'does not set the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to be_nil
+          end
+        end
+
+        context 'when the email is valid' do
+          let(:email) { 'test@test.com' }
+
+          it 'redirects to legal_services_rm6240_admin_edit_user_password_path' do
+            expect(response).to redirect_to legal_services_rm6240_admin_edit_user_password_path
+          end
+
+          it 'sets the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+          end
+        end
+      end
+
+      context 'when the email is valid but an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { email: 'test@test.com' }
+        end
+
+        context 'and the error is UserNotFoundException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
+
+          it 'redirects to the edit password page' do
+            expect(response).to redirect_to legal_services_rm6240_admin_edit_user_password_path
+          end
+        end
+
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to legal_services_rm6240_admin_new_user_password_path
+          end
+        end
+
+        context 'and the error is ServiceError' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to legal_services_rm6240_admin_new_user_password_path
+          end
+        end
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
       before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: email }
+        post :create, params: { email: 'test@test.com' }
         cookies.update(response.cookies)
       end
 
-      context 'when the email is invalid' do
-        let(:email) { 'testtest.com' }
-
-        it 'redirects to the legal_services_rm6240_admin_new_user_password_path' do
-          expect(response).to redirect_to legal_services_rm6240_admin_new_user_password_path
-        end
-
-        it 'does not set the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to be_nil
-        end
+      it 'redirects to legal_services_rm6240_admin_edit_user_password_path' do
+        expect(response).to redirect_to legal_services_rm6240_admin_edit_user_password_path
       end
 
-      context 'when the email is valid' do
-        let(:email) { 'test@test.com' }
-
-        it 'redirects to legal_services_rm6240_admin_edit_user_password_path' do
-          expect(response).to redirect_to legal_services_rm6240_admin_edit_user_password_path
-        end
-
-        it 'sets the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
-        end
-      end
-    end
-
-    context 'when the email is valid but an exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: 'test@test.com' }
-      end
-
-      context 'and the error is UserNotFoundException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
-
-        it 'redirects to the edit password page' do
-          expect(response).to redirect_to legal_services_rm6240_admin_edit_user_password_path
-        end
-      end
-
-      context 'and the error is InvalidParameterException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to legal_services_rm6240_admin_new_user_password_path
-        end
-      end
-
-      context 'and the error is ServiceError' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to legal_services_rm6240_admin_new_user_password_path
-        end
+      it 'sets the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET edit' do
-    before do
-      cookies[:crown_marketplace_reset_email] = 'test@email.com'
-      get :edit
+    context 'when the framework is live' do
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
     end
 
-    render_views
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
 
-    it 'renders the edit page' do
-      expect(response).to render_template(:edit)
-    end
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
 
-    it 'the email has been set correctly in the response object' do
-      expect(assigns(:response).email).to eq('test@email.com')
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
     end
   end
 
@@ -110,24 +161,46 @@ RSpec.describe LegalServices::RM6240::Admin::PasswordsController do
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
       # rubocop:enable RSpec/AnyInstance
-      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
-      cookies.update(response.cookies)
     end
 
-    context 'when the reset password is invalid' do
-      let(:password) { 'Pas12!' }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+    context 'when the framework is live' do
+      before do
+        put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+        cookies.update(response.cookies)
       end
 
-      it 'does not delete the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      context 'when the reset password is invalid' do
+        let(:password) { 'Pas12!' }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'does not delete the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+        end
+      end
+
+      context 'when the reset password is valid' do
+        let(:password) { 'Password12345!' }
+
+        it 'redirects to legal_services_rm6240_admin_password_reset_success_path' do
+          expect(response).to redirect_to legal_services_rm6240_admin_password_reset_success_path
+        end
+
+        it 'deletes the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to be_nil
+        end
       end
     end
 
-    context 'when the reset password is valid' do
-      let(:password) { 'Password12345!' }
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      before do
+        put :update, params: { email: 'test@test.com', password: 'Password12345!', password_confirmation: 'Password12345!', confirmation_code: '123456' }
+        cookies.update(response.cookies)
+      end
 
       it 'redirects to legal_services_rm6240_admin_password_reset_success_path' do
         expect(response).to redirect_to legal_services_rm6240_admin_password_reset_success_path
@@ -140,12 +213,22 @@ RSpec.describe LegalServices::RM6240::Admin::PasswordsController do
   end
 
   describe 'GET password_reset_success' do
-    before { get :password_reset_success }
+    context 'when the framework is live' do
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
 
-    render_views
+        expect(response).to render_template(:password_reset_success)
+      end
+    end
 
-    it 'renders the password_reset_success page' do
-      expect(response).to render_template(:password_reset_success)
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
+
+        expect(response).to render_template(:password_reset_success)
+      end
     end
   end
 end

--- a/spec/controllers/legal_services/rm6240/admin/sessions_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/admin/sessions_controller_spec.rb
@@ -10,10 +10,22 @@ RSpec.describe LegalServices::RM6240::Admin::SessionsController do
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'GET new' do
-    it 'renders the new page' do
-      get :new
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-      expect(response).to render_template(:new)
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the new page' do
+        get :new
+
+        expect(response).to render_template(:new)
+      end
     end
   end
 
@@ -114,6 +126,35 @@ RSpec.describe LegalServices::RM6240::Admin::SessionsController do
           expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
           expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
         end
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+      include_context 'with cognito structs'
+
+      let(:username) { user.cognito_uuid }
+      let(:session) { 'I_AM_THE_SESSION' }
+      let(:cognito_groups) do
+        admin_list_groups_for_user_resp_struct.new(
+          groups: [
+            cognito_group_struct.new(group_name: 'ccs_employee'),
+            cognito_group_struct.new(group_name: 'ls_access')
+          ]
+        )
+      end
+
+      before do
+        allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: nil, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+
+        post :create, params: { user: { email: email, password: 'Password12345!' } }
+        cookies.update(response.cookies)
+      end
+
+      it 'redirects to legal_services_rm6240_admin_uploads_path' do
+        expect(response).to redirect_to legal_services_rm6240_admin_uploads_path
       end
     end
   end

--- a/spec/controllers/legal_services/rm6240/admin/users_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/admin/users_controller_spec.rb
@@ -10,26 +10,51 @@ RSpec.describe LegalServices::RM6240::Admin::UsersController do
   describe 'GET challenge_new' do
     let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
 
-    before do
-      cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
-      get :challenge_new, params: { challenge_name: challenge_name }
-    end
+    before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
-    render_views
+    context 'when the framework is live' do
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
 
-    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
-      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+      render_views
 
-      it 'renders the new_password_required partial' do
-        expect(response).to render_template(partial: 'base/users/_new_password_required')
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
       end
     end
 
-    context 'when the challenge is SMS_MFA' do
-      let(:challenge_name) { 'SMS_MFA' }
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
 
-      it 'renders the sms_mfa partial' do
-        expect(response).to render_template(partial: 'base/users/_sms_mfa')
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
+
+      render_views
+
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
       end
     end
   end
@@ -58,47 +83,69 @@ RSpec.describe LegalServices::RM6240::Admin::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:password) { 'Pas12!' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
-        end
-      end
+        context 'and it is not valid' do
+          let(:password) { 'Pas12!' }
 
-      context 'and it is valid' do
-        context 'and there is an additional challange' do
-          let(:new_challenge_name) { 'SMS_MFA' }
-
-          it 'redirects to legal_services_rm6240_admin_users_challenge_path' do
-            expect(response).to redirect_to legal_services_rm6240_admin_users_challenge_path(challenge_name: new_challenge_name)
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
           end
 
-          it 'the cookies are updated correctly' do
-            expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
             expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
           end
         end
 
-        context 'and there is no additional challange' do
-          it 'redirects to legal_services_rm6240_admin_uploads_path' do
-            expect(response).to redirect_to legal_services_rm6240_admin_uploads_path
+        context 'and it is valid' do
+          context 'and there is an additional challange' do
+            let(:new_challenge_name) { 'SMS_MFA' }
+
+            it 'redirects to legal_services_rm6240_admin_users_challenge_path' do
+              expect(response).to redirect_to legal_services_rm6240_admin_users_challenge_path(challenge_name: new_challenge_name)
+            end
+
+            it 'the cookies are updated correctly' do
+              expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+              expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+            end
           end
 
-          it 'deletes the cookies' do
-            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
-            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          context 'and there is no additional challange' do
+            it 'redirects to legal_services_rm6240_admin_uploads_path' do
+              expect(response).to redirect_to legal_services_rm6240_admin_uploads_path
+            end
+
+            it 'deletes the cookies' do
+              expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+              expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+            end
           end
+        end
+      end
+
+      context 'when the framework is not live' do
+        include_context 'and RM6240 has expired'
+
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
+        end
+
+        it 'redirects to legal_services_rm6240_admin_uploads_path' do
+          expect(response).to redirect_to legal_services_rm6240_admin_uploads_path
+        end
+
+        it 'deletes the cookies' do
+          expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+          expect(cookies[:crown_marketplace_challenge_username]).to be_nil
         end
       end
     end
@@ -112,25 +159,47 @@ RSpec.describe LegalServices::RM6240::Admin::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:access_code) { '123' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        context 'and it is not valid' do
+          let(:access_code) { '123' }
+
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
+          end
+
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+            expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+          end
+        end
+
+        context 'and it is valid' do
+          it 'redirects to legal_services_rm6240_admin_uploads_path' do
+            expect(response).to redirect_to legal_services_rm6240_admin_uploads_path
+          end
+
+          it 'deletes the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          end
         end
       end
 
-      context 'and it is valid' do
+      context 'when the framework is not live' do
+        include_context 'and RM6240 has expired'
+
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
+        end
+
         it 'redirects to legal_services_rm6240_admin_uploads_path' do
           expect(response).to redirect_to legal_services_rm6240_admin_uploads_path
         end

--- a/spec/controllers/legal_services/rm6240/passwords_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/passwords_controller_spec.rb
@@ -8,98 +8,138 @@ RSpec.describe LegalServices::RM6240::PasswordsController do
   let(:default_params) { { service: 'legal_services', framework: 'RM6240' } }
 
   describe 'GET new' do
-    before { get :new }
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-    render_views
+        expect(response).to render_template(:new)
+      end
+    end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:new)
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
-    context 'when no exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: email }
-        cookies.update(response.cookies)
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    context 'when the framework is live' do
+      context 'when no exception is raised' do
+        before do
+          post :create, params: { email: email }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the email is invalid' do
+          let(:email) { 'testtest.com' }
+
+          it 'redirects to the legal_services_rm6240_new_user_password_path' do
+            expect(response).to redirect_to legal_services_rm6240_new_user_password_path
+          end
+
+          it 'does not set the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to be_nil
+          end
+        end
+
+        context 'when the email is valid' do
+          let(:email) { 'test@test.com' }
+
+          it 'redirects to legal_services_rm6240_edit_user_password_path' do
+            expect(response).to redirect_to legal_services_rm6240_edit_user_password_path
+          end
+
+          it 'sets the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+          end
+        end
       end
 
-      context 'when the email is invalid' do
-        let(:email) { 'testtest.com' }
-
-        it 'redirects to the legal_services_rm6240_new_user_password_path' do
-          expect(response).to redirect_to legal_services_rm6240_new_user_password_path
+      context 'when the email is valid but an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { email: 'test@test.com' }
         end
 
-        it 'does not set the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to be_nil
-        end
-      end
+        context 'and the error is UserNotFoundException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
 
-      context 'when the email is valid' do
-        let(:email) { 'test@test.com' }
-
-        it 'redirects to legal_services_rm6240_edit_user_password_path' do
-          expect(response).to redirect_to legal_services_rm6240_edit_user_password_path
+          it 'redirects to the edit password page' do
+            expect(response).to redirect_to legal_services_rm6240_edit_user_password_path
+          end
         end
 
-        it 'sets the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to legal_services_rm6240_new_user_password_path
+          end
+        end
+
+        context 'and the error is ServiceError' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to legal_services_rm6240_new_user_password_path
+          end
         end
       end
     end
 
-    context 'when the email is valid but an exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
-        # rubocop:enable RSpec/AnyInstance
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
         post :create, params: { email: 'test@test.com' }
-      end
 
-      context 'and the error is UserNotFoundException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
-
-        it 'redirects to the edit password page' do
-          expect(response).to redirect_to legal_services_rm6240_edit_user_password_path
-        end
-      end
-
-      context 'and the error is InvalidParameterException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to legal_services_rm6240_new_user_password_path
-        end
-      end
-
-      context 'and the error is ServiceError' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to legal_services_rm6240_new_user_password_path
-        end
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET edit' do
-    before do
-      cookies[:crown_marketplace_reset_email] = 'test@email.com'
-      get :edit
+    context 'when the framework is live' do
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
     end
 
-    render_views
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
 
-    it 'renders the edit page' do
-      expect(response).to render_template(:edit)
-    end
+      it 'renders the unrecognised framework page with the right http status' do
+        get :edit
 
-    it 'the email has been set correctly in the response object' do
-      expect(assigns(:response).email).to eq('test@email.com')
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
@@ -110,42 +150,69 @@ RSpec.describe LegalServices::RM6240::PasswordsController do
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
       # rubocop:enable RSpec/AnyInstance
-      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
-      cookies.update(response.cookies)
     end
 
-    context 'when the reset password is invalid' do
-      let(:password) { 'Pas12!' }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+    context 'when the framework is live' do
+      before do
+        put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+        cookies.update(response.cookies)
       end
 
-      it 'does not delete the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      context 'when the reset password is invalid' do
+        let(:password) { 'Pas12!' }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'does not delete the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+        end
+      end
+
+      context 'when the reset password is valid' do
+        let(:password) { 'Password12345!' }
+
+        it 'redirects to legal_services_rm6240_password_reset_success_path' do
+          expect(response).to redirect_to legal_services_rm6240_password_reset_success_path
+        end
+
+        it 'deletes the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to be_nil
+        end
       end
     end
 
-    context 'when the reset password is valid' do
-      let(:password) { 'Password12345!' }
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
 
-      it 'redirects to legal_services_rm6240_password_reset_success_path' do
-        expect(response).to redirect_to legal_services_rm6240_password_reset_success_path
-      end
+      it 'renders the unrecognised framework page with the right http status' do
+        put :update, params: { email: 'test@test.com', password: 'Password12345!', password_confirmation: 'Password12345', confirmation_code: '123456' }
 
-      it 'deletes the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to be_nil
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
 
   describe 'GET password_reset_success' do
-    before { get :password_reset_success }
+    context 'when the framework is live' do
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
 
-    render_views
+        expect(response).to render_template(:password_reset_success)
+      end
+    end
 
-    it 'renders the password_reset_success page' do
-      expect(response).to render_template(:password_reset_success)
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :password_reset_success
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 end

--- a/spec/controllers/legal_services/rm6240/registrations_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/registrations_controller_spec.rb
@@ -10,102 +10,139 @@ RSpec.describe LegalServices::RM6240::RegistrationsController do
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'GET new' do
-    before { get :new }
+    context 'when the framework is live' do
+      before { get :new }
 
-    render_views
+      it 'renders the new page' do
+        expect(response).to render_template(:new)
+      end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:new)
+      it 'gives the user the buyer and ls_access roles' do
+        expect(assigns(:result).roles).to eq(%i[buyer ls_access])
+      end
     end
 
-    it 'gives the user the buyer and ls_access roles' do
-      expect(assigns(:result).roles).to eq(%i[buyer ls_access])
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
     let(:email) { 'test@testemail.com' }
     let(:password) { 'Password890!' }
     let(:password_confirmation) { password }
 
-    context 'when no exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_return({ user_sub: '1234567890' })
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
-        allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
-        cookies.update(response.cookies)
-      end
+    context 'when the framework is live' do
+      context 'when no exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_return({ user_sub: '1234567890' })
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
+          allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          cookies.update(response.cookies)
+        end
 
-      context 'when the emaildomain is not on the allow list' do
-        let(:email) { 'test@fake-testemail.com' }
+        context 'when the emaildomain is not on the allow list' do
+          let(:email) { 'test@fake-testemail.com' }
 
-        it 'redirects to legal_services_rm6240_domain_not_on_safelist_path' do
-          expect(response).to redirect_to legal_services_rm6240_domain_not_on_safelist_path
+          it 'redirects to legal_services_rm6240_domain_not_on_safelist_path' do
+            expect(response).to redirect_to legal_services_rm6240_domain_not_on_safelist_path
+          end
+        end
+
+        context 'when some of the information is invalid' do
+          let(:password_confirmation) { 'I do not match the password' }
+
+          it 'renders the new page' do
+            expect(response).to render_template(:new)
+          end
+        end
+
+        context 'when all the information is valid' do
+          it 'redirects to legal_services_rm6240_users_confirm_path' do
+            expect(response).to redirect_to legal_services_rm6240_users_confirm_path
+          end
+
+          it 'sets the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+          end
         end
       end
 
-      context 'when some of the information is invalid' do
-        let(:password_confirmation) { 'I do not match the password' }
-
-        it 'renders the new page' do
-          expect(response).to render_template(:new)
-        end
-      end
-
-      context 'when all the information is valid' do
-        it 'redirects to legal_services_rm6240_users_confirm_path' do
-          expect(response).to redirect_to legal_services_rm6240_users_confirm_path
+      context 'when an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_raise(error.new('Some context', 'Some message'))
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
+          allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          cookies.update(response.cookies)
         end
 
-        it 'sets the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+        context 'and the error is UsernameExistsException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UsernameExistsException }
+
+          it 'redirects to legal_services_rm6240_users_confirm_path' do
+            expect(response).to redirect_to legal_services_rm6240_users_confirm_path
+          end
+
+          it 'sets the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+          end
+        end
+
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'renders the new page' do
+            expect(response).to render_template(:new)
+          end
         end
       end
     end
 
-    context 'when an exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_raise(error.new('Some context', 'Some message'))
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
-        allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
-        # rubocop:enable RSpec/AnyInstance
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
         post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
-        cookies.update(response.cookies)
-      end
 
-      context 'and the error is UsernameExistsException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::UsernameExistsException }
-
-        it 'redirects to legal_services_rm6240_users_confirm_path' do
-          expect(response).to redirect_to legal_services_rm6240_users_confirm_path
-        end
-
-        it 'sets the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq email
-        end
-      end
-
-      context 'and the error is InvalidParameterException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
-
-        it 'renders the new page' do
-          expect(response).to render_template(:new)
-        end
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET domain_not_on_safelist' do
-    before { get :domain_not_on_safelist }
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :domain_not_on_safelist
 
-    render_views
+        expect(response).to render_template(:domain_not_on_safelist)
+      end
+    end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:domain_not_on_safelist)
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :domain_not_on_safelist
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 end

--- a/spec/controllers/legal_services/rm6240/sessions_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/sessions_controller_spec.rb
@@ -10,10 +10,23 @@ RSpec.describe LegalServices::RM6240::SessionsController do
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'GET new' do
-    it 'renders the new page' do
-      get :new
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-      expect(response).to render_template(:new)
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
@@ -114,6 +127,17 @@ RSpec.describe LegalServices::RM6240::SessionsController do
           expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
           expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
         end
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        post :create, params: { user: { email: email, password: 'Password12345!' } }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/controllers/legal_services/rm6240/users_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/users_controller_spec.rb
@@ -8,12 +8,23 @@ RSpec.describe LegalServices::RM6240::UsersController do
   let(:default_params) { { service: 'legal_services', framework: 'RM6240' } }
 
   describe 'GET confirm_new' do
-    before { get :confirm_new }
+    context 'when the framework is live' do
+      it 'renders the confirm_new page' do
+        get :confirm_new
 
-    render_views
+        expect(response).to render_template(:confirm_new)
+      end
+    end
 
-    it 'renders the confirm_new page' do
-      expect(response).to render_template(:confirm_new)
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :confirm_new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
@@ -22,71 +33,86 @@ RSpec.describe LegalServices::RM6240::UsersController do
     let(:user_email) { user.email }
     let(:confirmation_code) { '123456' }
 
-    context 'and there is no exception' do
-      before do
-        cookies[:crown_marketplace_confirmation_email] = user_email
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
-        cookies.update(response.cookies)
+    # rubocop:disable RSpec/NestedGroups
+    context 'when the framework is live' do
+      context 'and there is no exception' do
+        before do
+          cookies[:crown_marketplace_confirmation_email] = user_email
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_return(true)
+          # rubocop:enable RSpec/AnyInstance
+          post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the information is invalid' do
+          let(:confirmation_code) { '' }
+
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
+        end
+
+        context 'when the information is valid' do
+          it 'redirects to legal_services_journey_start_path' do
+            expect(response).to redirect_to legal_services_journey_start_path
+          end
+
+          it 'deletes the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to be_nil
+          end
+        end
       end
 
-      context 'when the information is invalid' do
-        let(:confirmation_code) { '' }
-
-        it 'renders confirm_new' do
-          expect(response).to render_template(:confirm_new)
+      context 'and there is an exception' do
+        before do
+          cookies[:crown_marketplace_confirmation_email] = user_email
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
-        end
-      end
+        context 'when the exception is generic' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
 
-      context 'when the information is valid' do
-        it 'redirects to legal_services_journey_start_path' do
-          expect(response).to redirect_to legal_services_journey_start_path
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
         end
 
-        it 'deletes the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to be_nil
+        context 'when the exception is NotAuthorizedException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::NotAuthorizedException }
+
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
         end
       end
     end
+    # rubocop:enable RSpec/NestedGroups
 
-    context 'and there is an exception' do
-      before do
-        cookies[:crown_marketplace_confirmation_email] = user_email
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_raise(error.new('Some context', 'Some message'))
-        # rubocop:enable RSpec/AnyInstance
-        post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
-        cookies.update(response.cookies)
-      end
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
 
-      context 'when the exception is generic' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+      it 'renders the unrecognised framework page with the right http status' do
+        post :confirm, params: { email: user_email, confirmation_code: '123456' }
 
-        it 'renders confirm_new' do
-          expect(response).to render_template(:confirm_new)
-        end
-
-        it 'does not delete the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
-        end
-      end
-
-      context 'when the exception is NotAuthorizedException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::NotAuthorizedException }
-
-        it 'renders confirm_new' do
-          expect(response).to render_template(:confirm_new)
-        end
-
-        it 'does not delete the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
-        end
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -94,39 +120,64 @@ RSpec.describe LegalServices::RM6240::UsersController do
   describe 'POST resend_confirmation_email' do
     let(:email) { 'test@testemail.com' }
 
-    before do
-      allow(Cognito::ResendConfirmationCode).to receive(:call).with(email).and_return(Cognito::ResendConfirmationCode.new(email))
-      post :resend_confirmation_email, params: { email: email }
+    context 'when the framework is live' do
+      before do
+        allow(Cognito::ResendConfirmationCode).to receive(:call).with(email).and_return(Cognito::ResendConfirmationCode.new(email))
+        post :resend_confirmation_email, params: { email: email }
+      end
+
+      it 'redirects to legal_services_rm6240_users_confirm_path' do
+        expect(response).to redirect_to legal_services_rm6240_users_confirm_path
+      end
     end
 
-    it 'redirects to legal_services_rm6240_users_confirm_path' do
-      expect(response).to redirect_to legal_services_rm6240_users_confirm_path
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        post :resend_confirmation_email, params: { email: email }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
   describe 'GET challenge_new' do
     let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
 
-    before do
-      cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
-      get :challenge_new, params: { challenge_name: challenge_name }
-    end
+    before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
-    render_views
+    context 'when the framework is live' do
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
 
-    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
-      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+      render_views
 
-      it 'renders the new_password_required partial' do
-        expect(response).to render_template(partial: 'base/users/_new_password_required')
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
       end
     end
 
-    context 'when the challenge is SMS_MFA' do
-      let(:challenge_name) { 'SMS_MFA' }
+    context 'when the framework is not live' do
+      include_context 'and RM6240 has expired'
 
-      it 'renders the sms_mfa partial' do
-        expect(response).to render_template(partial: 'base/users/_sms_mfa')
+      it 'renders the unrecognised framework page with the right http status' do
+        get :challenge_new, params: { challenge_name: 'NEW_PASSWORD_REQUIRED' }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -155,47 +206,62 @@ RSpec.describe LegalServices::RM6240::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:password) { 'Pas12!' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
-        end
-      end
+        context 'and it is not valid' do
+          let(:password) { 'Pas12!' }
 
-      context 'and it is valid' do
-        context 'and there is an additional challange' do
-          let(:new_challenge_name) { 'SMS_MFA' }
-
-          it 'redirects to legal_services_rm6240_users_challenge_path' do
-            expect(response).to redirect_to legal_services_rm6240_users_challenge_path(challenge_name: new_challenge_name)
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
           end
 
-          it 'the cookies are updated correctly' do
-            expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
             expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
           end
         end
 
-        context 'and there is no additional challange' do
-          it 'redirects to legal_services_journey_start_path' do
-            expect(response).to redirect_to legal_services_journey_start_path
+        context 'and it is valid' do
+          context 'and there is an additional challange' do
+            let(:new_challenge_name) { 'SMS_MFA' }
+
+            it 'redirects to legal_services_rm6240_users_challenge_path' do
+              expect(response).to redirect_to legal_services_rm6240_users_challenge_path(challenge_name: new_challenge_name)
+            end
+
+            it 'the cookies are updated correctly' do
+              expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+              expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+            end
           end
 
-          it 'deletes the cookies' do
-            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
-            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          context 'and there is no additional challange' do
+            it 'redirects to legal_services_journey_start_path' do
+              expect(response).to redirect_to legal_services_journey_start_path
+            end
+
+            it 'deletes the cookies' do
+              expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+              expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+            end
           end
+        end
+      end
+
+      context 'when the framework is not live' do
+        include_context 'and RM6240 has expired'
+
+        it 'renders the unrecognised framework page with the right http status' do
+          post :challenge, params: { challenge_name: 'SMS_MFA', username: username, session: session }
+
+          expect(response).to render_template('home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end
@@ -209,32 +275,47 @@ RSpec.describe LegalServices::RM6240::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:access_code) { '123' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        context 'and it is not valid' do
+          let(:access_code) { '123' }
+
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
+          end
+
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+            expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+          end
+        end
+
+        context 'and it is valid' do
+          it 'redirects to legal_services_journey_start_path' do
+            expect(response).to redirect_to legal_services_journey_start_path
+          end
+
+          it 'deletes the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          end
         end
       end
 
-      context 'and it is valid' do
-        it 'redirects to legal_services_journey_start_path' do
-          expect(response).to redirect_to legal_services_journey_start_path
-        end
+      context 'when the framework is not live' do
+        include_context 'and RM6240 has expired'
 
-        it 'deletes the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to be_nil
-          expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+        it 'renders the unrecognised framework page with the right http status' do
+          post :challenge, params: { challenge_name: 'SMS_MFA', username: username, session: session }
+
+          expect(response).to render_template('home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end

--- a/spec/controllers/management_consultancy/rm6187/admin/passwords_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/admin/passwords_controller_spec.rb
@@ -8,98 +8,149 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::PasswordsController do
   let(:default_params) { { service: 'management_consultancy/admin', framework: 'RM6187' } }
 
   describe 'GET new' do
-    before { get :new }
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-    render_views
+        expect(response).to render_template(:new)
+      end
+    end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:new)
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the new page' do
+        get :new
+
+        expect(response).to render_template(:new)
+      end
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
-    context 'when no exception is raised' do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    context 'when the framework is live' do
+      context 'when no exception is raised' do
+        before do
+          post :create, params: { email: email }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the email is invalid' do
+          let(:email) { 'testtest.com' }
+
+          it 'redirects to the management_consultancy_rm6187_admin_new_user_password_path' do
+            expect(response).to redirect_to management_consultancy_rm6187_admin_new_user_password_path
+          end
+
+          it 'does not set the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to be_nil
+          end
+        end
+
+        context 'when the email is valid' do
+          let(:email) { 'test@test.com' }
+
+          it 'redirects to management_consultancy_rm6187_admin_edit_user_password_path' do
+            expect(response).to redirect_to management_consultancy_rm6187_admin_edit_user_password_path
+          end
+
+          it 'sets the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+          end
+        end
+      end
+
+      context 'when the email is valid but an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { email: 'test@test.com' }
+        end
+
+        context 'and the error is UserNotFoundException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
+
+          it 'redirects to the edit password page' do
+            expect(response).to redirect_to management_consultancy_rm6187_admin_edit_user_password_path
+          end
+        end
+
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to management_consultancy_rm6187_admin_new_user_password_path
+          end
+        end
+
+        context 'and the error is ServiceError' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to management_consultancy_rm6187_admin_new_user_password_path
+          end
+        end
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
       before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: email }
+        post :create, params: { email: 'test@test.com' }
         cookies.update(response.cookies)
       end
 
-      context 'when the email is invalid' do
-        let(:email) { 'testtest.com' }
-
-        it 'redirects to the management_consultancy_rm6187_admin_new_user_password_path' do
-          expect(response).to redirect_to management_consultancy_rm6187_admin_new_user_password_path
-        end
-
-        it 'does not set the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to be_nil
-        end
+      it 'redirects to management_consultancy_rm6187_admin_edit_user_password_path' do
+        expect(response).to redirect_to management_consultancy_rm6187_admin_edit_user_password_path
       end
 
-      context 'when the email is valid' do
-        let(:email) { 'test@test.com' }
-
-        it 'redirects to management_consultancy_rm6187_admin_edit_user_password_path' do
-          expect(response).to redirect_to management_consultancy_rm6187_admin_edit_user_password_path
-        end
-
-        it 'sets the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
-        end
-      end
-    end
-
-    context 'when the email is valid but an exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: 'test@test.com' }
-      end
-
-      context 'and the error is UserNotFoundException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
-
-        it 'redirects to the edit password page' do
-          expect(response).to redirect_to management_consultancy_rm6187_admin_edit_user_password_path
-        end
-      end
-
-      context 'and the error is InvalidParameterException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to management_consultancy_rm6187_admin_new_user_password_path
-        end
-      end
-
-      context 'and the error is ServiceError' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to management_consultancy_rm6187_admin_new_user_password_path
-        end
+      it 'sets the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET edit' do
-    before do
-      cookies[:crown_marketplace_reset_email] = 'test@email.com'
-      get :edit
+    context 'when the framework is live' do
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
     end
 
-    render_views
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
 
-    it 'renders the edit page' do
-      expect(response).to render_template(:edit)
-    end
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
 
-    it 'the email has been set correctly in the response object' do
-      expect(assigns(:response).email).to eq('test@email.com')
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
     end
   end
 
@@ -110,24 +161,46 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::PasswordsController do
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
       # rubocop:enable RSpec/AnyInstance
-      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
-      cookies.update(response.cookies)
     end
 
-    context 'when the reset password is invalid' do
-      let(:password) { 'Pas12!' }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+    context 'when the framework is live' do
+      before do
+        put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+        cookies.update(response.cookies)
       end
 
-      it 'does not delete the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      context 'when the reset password is invalid' do
+        let(:password) { 'Pas12!' }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'does not delete the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+        end
+      end
+
+      context 'when the reset password is valid' do
+        let(:password) { 'Password12345!' }
+
+        it 'redirects to management_consultancy_rm6187_admin_password_reset_success_path' do
+          expect(response).to redirect_to management_consultancy_rm6187_admin_password_reset_success_path
+        end
+
+        it 'deletes the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to be_nil
+        end
       end
     end
 
-    context 'when the reset password is valid' do
-      let(:password) { 'Password12345!' }
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      before do
+        put :update, params: { email: 'test@test.com', password: 'Password12345!', password_confirmation: 'Password12345!', confirmation_code: '123456' }
+        cookies.update(response.cookies)
+      end
 
       it 'redirects to management_consultancy_rm6187_admin_password_reset_success_path' do
         expect(response).to redirect_to management_consultancy_rm6187_admin_password_reset_success_path
@@ -140,12 +213,22 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::PasswordsController do
   end
 
   describe 'GET password_reset_success' do
-    before { get :password_reset_success }
+    context 'when the framework is live' do
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
 
-    render_views
+        expect(response).to render_template(:password_reset_success)
+      end
+    end
 
-    it 'renders the password_reset_success page' do
-      expect(response).to render_template(:password_reset_success)
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
+
+        expect(response).to render_template(:password_reset_success)
+      end
     end
   end
 end

--- a/spec/controllers/management_consultancy/rm6187/admin/users_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/admin/users_controller_spec.rb
@@ -10,26 +10,51 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::UsersController do
   describe 'GET challenge_new' do
     let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
 
-    before do
-      cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
-      get :challenge_new, params: { challenge_name: challenge_name }
-    end
+    before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
-    render_views
+    context 'when the framework is live' do
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
 
-    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
-      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+      render_views
 
-      it 'renders the new_password_required partial' do
-        expect(response).to render_template(partial: 'base/users/_new_password_required')
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
       end
     end
 
-    context 'when the challenge is SMS_MFA' do
-      let(:challenge_name) { 'SMS_MFA' }
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
 
-      it 'renders the sms_mfa partial' do
-        expect(response).to render_template(partial: 'base/users/_sms_mfa')
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
+
+      render_views
+
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
       end
     end
   end
@@ -58,47 +83,69 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:password) { 'Pas12!' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
-        end
-      end
+        context 'and it is not valid' do
+          let(:password) { 'Pas12!' }
 
-      context 'and it is valid' do
-        context 'and there is an additional challange' do
-          let(:new_challenge_name) { 'SMS_MFA' }
-
-          it 'redirects to management_consultancy_rm6187_admin_users_challenge_path' do
-            expect(response).to redirect_to management_consultancy_rm6187_admin_users_challenge_path(challenge_name: new_challenge_name)
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
           end
 
-          it 'the cookies are updated correctly' do
-            expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
             expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
           end
         end
 
-        context 'and there is no additional challange' do
-          it 'redirects to management_consultancy_rm6187_admin_uploads_path' do
-            expect(response).to redirect_to management_consultancy_rm6187_admin_uploads_path
+        context 'and it is valid' do
+          context 'and there is an additional challange' do
+            let(:new_challenge_name) { 'SMS_MFA' }
+
+            it 'redirects to management_consultancy_rm6187_admin_users_challenge_path' do
+              expect(response).to redirect_to management_consultancy_rm6187_admin_users_challenge_path(challenge_name: new_challenge_name)
+            end
+
+            it 'the cookies are updated correctly' do
+              expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+              expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+            end
           end
 
-          it 'deletes the cookies' do
-            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
-            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          context 'and there is no additional challange' do
+            it 'redirects to management_consultancy_rm6187_admin_uploads_path' do
+              expect(response).to redirect_to management_consultancy_rm6187_admin_uploads_path
+            end
+
+            it 'deletes the cookies' do
+              expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+              expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+            end
           end
+        end
+      end
+
+      context 'when the framework is not live' do
+        include_context 'and RM6187 has expired'
+
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
+        end
+
+        it 'redirects to management_consultancy_rm6187_admin_uploads_path' do
+          expect(response).to redirect_to management_consultancy_rm6187_admin_uploads_path
+        end
+
+        it 'deletes the cookies' do
+          expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+          expect(cookies[:crown_marketplace_challenge_username]).to be_nil
         end
       end
     end
@@ -112,25 +159,47 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:access_code) { '123' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        context 'and it is not valid' do
+          let(:access_code) { '123' }
+
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
+          end
+
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+            expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+          end
+        end
+
+        context 'and it is valid' do
+          it 'redirects to management_consultancy_rm6187_admin_uploads_path' do
+            expect(response).to redirect_to management_consultancy_rm6187_admin_uploads_path
+          end
+
+          it 'deletes the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          end
         end
       end
 
-      context 'and it is valid' do
+      context 'when the framework is not live' do
+        include_context 'and RM6187 has expired'
+
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
+        end
+
         it 'redirects to management_consultancy_rm6187_admin_uploads_path' do
           expect(response).to redirect_to management_consultancy_rm6187_admin_uploads_path
         end

--- a/spec/controllers/management_consultancy/rm6187/passwords_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/passwords_controller_spec.rb
@@ -8,98 +8,138 @@ RSpec.describe ManagementConsultancy::RM6187::PasswordsController do
   let(:default_params) { { service: 'management_consultancy', framework: 'RM6187' } }
 
   describe 'GET new' do
-    before { get :new }
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-    render_views
+        expect(response).to render_template(:new)
+      end
+    end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:new)
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
-    context 'when no exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: email }
-        cookies.update(response.cookies)
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    context 'when the framework is live' do
+      context 'when no exception is raised' do
+        before do
+          post :create, params: { email: email }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the email is invalid' do
+          let(:email) { 'testtest.com' }
+
+          it 'redirects to the management_consultancy_rm6187_new_user_password_path' do
+            expect(response).to redirect_to management_consultancy_rm6187_new_user_password_path
+          end
+
+          it 'does not set the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to be_nil
+          end
+        end
+
+        context 'when the email is valid' do
+          let(:email) { 'test@test.com' }
+
+          it 'redirects to management_consultancy_rm6187_edit_user_password_path' do
+            expect(response).to redirect_to management_consultancy_rm6187_edit_user_password_path
+          end
+
+          it 'sets the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+          end
+        end
       end
 
-      context 'when the email is invalid' do
-        let(:email) { 'testtest.com' }
-
-        it 'redirects to the management_consultancy_rm6187_new_user_password_path' do
-          expect(response).to redirect_to management_consultancy_rm6187_new_user_password_path
+      context 'when the email is valid but an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { email: 'test@test.com' }
         end
 
-        it 'does not set the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to be_nil
-        end
-      end
+        context 'and the error is UserNotFoundException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
 
-      context 'when the email is valid' do
-        let(:email) { 'test@test.com' }
-
-        it 'redirects to management_consultancy_rm6187_edit_user_password_path' do
-          expect(response).to redirect_to management_consultancy_rm6187_edit_user_password_path
+          it 'redirects to the edit password page' do
+            expect(response).to redirect_to management_consultancy_rm6187_edit_user_password_path
+          end
         end
 
-        it 'sets the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to management_consultancy_rm6187_new_user_password_path
+          end
+        end
+
+        context 'and the error is ServiceError' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to management_consultancy_rm6187_new_user_password_path
+          end
         end
       end
     end
 
-    context 'when the email is valid but an exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
-        # rubocop:enable RSpec/AnyInstance
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
         post :create, params: { email: 'test@test.com' }
-      end
 
-      context 'and the error is UserNotFoundException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
-
-        it 'redirects to the edit password page' do
-          expect(response).to redirect_to management_consultancy_rm6187_edit_user_password_path
-        end
-      end
-
-      context 'and the error is InvalidParameterException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to management_consultancy_rm6187_new_user_password_path
-        end
-      end
-
-      context 'and the error is ServiceError' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to management_consultancy_rm6187_new_user_password_path
-        end
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET edit' do
-    before do
-      cookies[:crown_marketplace_reset_email] = 'test@email.com'
-      get :edit
+    context 'when the framework is live' do
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
     end
 
-    render_views
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
 
-    it 'renders the edit page' do
-      expect(response).to render_template(:edit)
-    end
+      it 'renders the unrecognised framework page with the right http status' do
+        get :edit
 
-    it 'the email has been set correctly in the response object' do
-      expect(assigns(:response).email).to eq('test@email.com')
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
@@ -110,42 +150,69 @@ RSpec.describe ManagementConsultancy::RM6187::PasswordsController do
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
       # rubocop:enable RSpec/AnyInstance
-      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
-      cookies.update(response.cookies)
     end
 
-    context 'when the reset password is invalid' do
-      let(:password) { 'Pas12!' }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+    context 'when the framework is live' do
+      before do
+        put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+        cookies.update(response.cookies)
       end
 
-      it 'does not delete the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      context 'when the reset password is invalid' do
+        let(:password) { 'Pas12!' }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'does not delete the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+        end
+      end
+
+      context 'when the reset password is valid' do
+        let(:password) { 'Password12345!' }
+
+        it 'redirects to management_consultancy_rm6187_password_reset_success_path' do
+          expect(response).to redirect_to management_consultancy_rm6187_password_reset_success_path
+        end
+
+        it 'deletes the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to be_nil
+        end
       end
     end
 
-    context 'when the reset password is valid' do
-      let(:password) { 'Password12345!' }
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
 
-      it 'redirects to management_consultancy_rm6187_password_reset_success_path' do
-        expect(response).to redirect_to management_consultancy_rm6187_password_reset_success_path
-      end
+      it 'renders the unrecognised framework page with the right http status' do
+        put :update, params: { email: 'test@test.com', password: 'Password12345!', password_confirmation: 'Password12345', confirmation_code: '123456' }
 
-      it 'deletes the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to be_nil
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
 
   describe 'GET password_reset_success' do
-    before { get :password_reset_success }
+    context 'when the framework is live' do
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
 
-    render_views
+        expect(response).to render_template(:password_reset_success)
+      end
+    end
 
-    it 'renders the password_reset_success page' do
-      expect(response).to render_template(:password_reset_success)
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :password_reset_success
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 end

--- a/spec/controllers/management_consultancy/rm6187/registrations_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/registrations_controller_spec.rb
@@ -10,102 +10,139 @@ RSpec.describe ManagementConsultancy::RM6187::RegistrationsController do
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'GET new' do
-    before { get :new }
+    context 'when the framework is live' do
+      before { get :new }
 
-    render_views
+      it 'renders the new page' do
+        expect(response).to render_template(:new)
+      end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:new)
+      it 'gives the user the buyer and mc_access roles' do
+        expect(assigns(:result).roles).to eq(%i[buyer mc_access])
+      end
     end
 
-    it 'gives the user the buyer and mc_access roles' do
-      expect(assigns(:result).roles).to eq(%i[buyer mc_access])
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
     let(:email) { 'test@testemail.com' }
     let(:password) { 'Password890!' }
     let(:password_confirmation) { password }
 
-    context 'when no exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_return({ user_sub: '1234567890' })
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
-        allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
-        cookies.update(response.cookies)
-      end
+    context 'when the framework is live' do
+      context 'when no exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_return({ user_sub: '1234567890' })
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
+          allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          cookies.update(response.cookies)
+        end
 
-      context 'when the emaildomain is not on the allow list' do
-        let(:email) { 'test@fake-testemail.com' }
+        context 'when the emaildomain is not on the allow list' do
+          let(:email) { 'test@fake-testemail.com' }
 
-        it 'redirects to management_consultancy_rm6187_domain_not_on_safelist_path' do
-          expect(response).to redirect_to management_consultancy_rm6187_domain_not_on_safelist_path
+          it 'redirects to management_consultancy_rm6187_domain_not_on_safelist_path' do
+            expect(response).to redirect_to management_consultancy_rm6187_domain_not_on_safelist_path
+          end
+        end
+
+        context 'when some of the information is invalid' do
+          let(:password_confirmation) { 'I do not match the password' }
+
+          it 'renders the new page' do
+            expect(response).to render_template(:new)
+          end
+        end
+
+        context 'when all the information is valid' do
+          it 'redirects to management_consultancy_rm6187_users_confirm_path' do
+            expect(response).to redirect_to management_consultancy_rm6187_users_confirm_path
+          end
+
+          it 'sets the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+          end
         end
       end
 
-      context 'when some of the information is invalid' do
-        let(:password_confirmation) { 'I do not match the password' }
-
-        it 'renders the new page' do
-          expect(response).to render_template(:new)
-        end
-      end
-
-      context 'when all the information is valid' do
-        it 'redirects to management_consultancy_rm6187_users_confirm_path' do
-          expect(response).to redirect_to management_consultancy_rm6187_users_confirm_path
+      context 'when an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_raise(error.new('Some context', 'Some message'))
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
+          allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          cookies.update(response.cookies)
         end
 
-        it 'sets the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+        context 'and the error is UsernameExistsException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UsernameExistsException }
+
+          it 'redirects to management_consultancy_rm6187_users_confirm_path' do
+            expect(response).to redirect_to management_consultancy_rm6187_users_confirm_path
+          end
+
+          it 'sets the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+          end
+        end
+
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'renders the new page' do
+            expect(response).to render_template(:new)
+          end
         end
       end
     end
 
-    context 'when an exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_raise(error.new('Some context', 'Some message'))
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
-        allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
-        # rubocop:enable RSpec/AnyInstance
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
         post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
-        cookies.update(response.cookies)
-      end
 
-      context 'and the error is UsernameExistsException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::UsernameExistsException }
-
-        it 'redirects to management_consultancy_rm6187_users_confirm_path' do
-          expect(response).to redirect_to management_consultancy_rm6187_users_confirm_path
-        end
-
-        it 'sets the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq email
-        end
-      end
-
-      context 'and the error is InvalidParameterException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
-
-        it 'renders the new page' do
-          expect(response).to render_template(:new)
-        end
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET domain_not_on_safelist' do
-    before { get :domain_not_on_safelist }
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :domain_not_on_safelist
 
-    render_views
+        expect(response).to render_template(:domain_not_on_safelist)
+      end
+    end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:domain_not_on_safelist)
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :domain_not_on_safelist
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 end

--- a/spec/controllers/management_consultancy/rm6187/sessions_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/sessions_controller_spec.rb
@@ -10,10 +10,23 @@ RSpec.describe ManagementConsultancy::RM6187::SessionsController do
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'GET new' do
-    it 'renders the new page' do
-      get :new
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-      expect(response).to render_template(:new)
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
@@ -114,6 +127,17 @@ RSpec.describe ManagementConsultancy::RM6187::SessionsController do
           expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
           expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
         end
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        post :create, params: { user: { email: email, password: 'Password12345!' } }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/controllers/management_consultancy/rm6187/users_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/users_controller_spec.rb
@@ -8,12 +8,23 @@ RSpec.describe ManagementConsultancy::RM6187::UsersController do
   let(:default_params) { { service: 'management_consultancy', framework: 'RM6187' } }
 
   describe 'GET confirm_new' do
-    before { get :confirm_new }
+    context 'when the framework is live' do
+      it 'renders the confirm_new page' do
+        get :confirm_new
 
-    render_views
+        expect(response).to render_template(:confirm_new)
+      end
+    end
 
-    it 'renders the confirm_new page' do
-      expect(response).to render_template(:confirm_new)
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :confirm_new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
@@ -22,71 +33,86 @@ RSpec.describe ManagementConsultancy::RM6187::UsersController do
     let(:user_email) { user.email }
     let(:confirmation_code) { '123456' }
 
-    context 'and there is no exception' do
-      before do
-        cookies[:crown_marketplace_confirmation_email] = user_email
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
-        cookies.update(response.cookies)
+    # rubocop:disable RSpec/NestedGroups
+    context 'when the framework is live' do
+      context 'and there is no exception' do
+        before do
+          cookies[:crown_marketplace_confirmation_email] = user_email
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_return(true)
+          # rubocop:enable RSpec/AnyInstance
+          post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the information is invalid' do
+          let(:confirmation_code) { '' }
+
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
+        end
+
+        context 'when the information is valid' do
+          it 'redirects to management_consultancy_journey_start_path' do
+            expect(response).to redirect_to management_consultancy_journey_start_path
+          end
+
+          it 'deletes the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to be_nil
+          end
+        end
       end
 
-      context 'when the information is invalid' do
-        let(:confirmation_code) { '' }
-
-        it 'renders confirm_new' do
-          expect(response).to render_template(:confirm_new)
+      context 'and there is an exception' do
+        before do
+          cookies[:crown_marketplace_confirmation_email] = user_email
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
-        end
-      end
+        context 'when the exception is generic' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
 
-      context 'when the information is valid' do
-        it 'redirects to management_consultancy_journey_start_path' do
-          expect(response).to redirect_to management_consultancy_journey_start_path
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
         end
 
-        it 'deletes the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to be_nil
+        context 'when the exception is NotAuthorizedException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::NotAuthorizedException }
+
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
         end
       end
     end
+    # rubocop:enable RSpec/NestedGroups
 
-    context 'and there is an exception' do
-      before do
-        cookies[:crown_marketplace_confirmation_email] = user_email
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_raise(error.new('Some context', 'Some message'))
-        # rubocop:enable RSpec/AnyInstance
-        post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
-        cookies.update(response.cookies)
-      end
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
 
-      context 'when the exception is generic' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+      it 'renders the unrecognised framework page with the right http status' do
+        post :confirm, params: { email: user_email, confirmation_code: '123456' }
 
-        it 'renders confirm_new' do
-          expect(response).to render_template(:confirm_new)
-        end
-
-        it 'does not delete the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
-        end
-      end
-
-      context 'when the exception is NotAuthorizedException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::NotAuthorizedException }
-
-        it 'renders confirm_new' do
-          expect(response).to render_template(:confirm_new)
-        end
-
-        it 'does not delete the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
-        end
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -94,39 +120,64 @@ RSpec.describe ManagementConsultancy::RM6187::UsersController do
   describe 'POST resend_confirmation_email' do
     let(:email) { 'test@testemail.com' }
 
-    before do
-      allow(Cognito::ResendConfirmationCode).to receive(:call).with(email).and_return(Cognito::ResendConfirmationCode.new(email))
-      post :resend_confirmation_email, params: { email: email }
+    context 'when the framework is live' do
+      before do
+        allow(Cognito::ResendConfirmationCode).to receive(:call).with(email).and_return(Cognito::ResendConfirmationCode.new(email))
+        post :resend_confirmation_email, params: { email: email }
+      end
+
+      it 'redirects to management_consultancy_rm6187_users_confirm_path' do
+        expect(response).to redirect_to management_consultancy_rm6187_users_confirm_path
+      end
     end
 
-    it 'redirects to management_consultancy_rm6187_users_confirm_path' do
-      expect(response).to redirect_to management_consultancy_rm6187_users_confirm_path
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        post :resend_confirmation_email, params: { email: email }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
   describe 'GET challenge_new' do
     let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
 
-    before do
-      cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
-      get :challenge_new, params: { challenge_name: challenge_name }
-    end
+    before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
-    render_views
+    context 'when the framework is live' do
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
 
-    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
-      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+      render_views
 
-      it 'renders the new_password_required partial' do
-        expect(response).to render_template(partial: 'base/users/_new_password_required')
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
       end
     end
 
-    context 'when the challenge is SMS_MFA' do
-      let(:challenge_name) { 'SMS_MFA' }
+    context 'when the framework is not live' do
+      include_context 'and RM6187 has expired'
 
-      it 'renders the sms_mfa partial' do
-        expect(response).to render_template(partial: 'base/users/_sms_mfa')
+      it 'renders the unrecognised framework page with the right http status' do
+        get :challenge_new, params: { challenge_name: 'NEW_PASSWORD_REQUIRED' }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -155,47 +206,62 @@ RSpec.describe ManagementConsultancy::RM6187::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:password) { 'Pas12!' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
-        end
-      end
+        context 'and it is not valid' do
+          let(:password) { 'Pas12!' }
 
-      context 'and it is valid' do
-        context 'and there is an additional challange' do
-          let(:new_challenge_name) { 'SMS_MFA' }
-
-          it 'redirects to management_consultancy_rm6187_users_challenge_path' do
-            expect(response).to redirect_to management_consultancy_rm6187_users_challenge_path(challenge_name: new_challenge_name)
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
           end
 
-          it 'the cookies are updated correctly' do
-            expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
             expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
           end
         end
 
-        context 'and there is no additional challange' do
-          it 'redirects to management_consultancy_journey_start_path' do
-            expect(response).to redirect_to management_consultancy_journey_start_path
+        context 'and it is valid' do
+          context 'and there is an additional challange' do
+            let(:new_challenge_name) { 'SMS_MFA' }
+
+            it 'redirects to management_consultancy_rm6187_users_challenge_path' do
+              expect(response).to redirect_to management_consultancy_rm6187_users_challenge_path(challenge_name: new_challenge_name)
+            end
+
+            it 'the cookies are updated correctly' do
+              expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+              expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+            end
           end
 
-          it 'deletes the cookies' do
-            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
-            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          context 'and there is no additional challange' do
+            it 'redirects to management_consultancy_journey_start_path' do
+              expect(response).to redirect_to management_consultancy_journey_start_path
+            end
+
+            it 'deletes the cookies' do
+              expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+              expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+            end
           end
+        end
+      end
+
+      context 'when the framework is not live' do
+        include_context 'and RM6187 has expired'
+
+        it 'renders the unrecognised framework page with the right http status' do
+          post :challenge, params: { challenge_name: 'SMS_MFA', username: username, session: session }
+
+          expect(response).to render_template('home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end
@@ -209,32 +275,47 @@ RSpec.describe ManagementConsultancy::RM6187::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:access_code) { '123' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        context 'and it is not valid' do
+          let(:access_code) { '123' }
+
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
+          end
+
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+            expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+          end
+        end
+
+        context 'and it is valid' do
+          it 'redirects to management_consultancy_journey_start_path' do
+            expect(response).to redirect_to management_consultancy_journey_start_path
+          end
+
+          it 'deletes the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          end
         end
       end
 
-      context 'and it is valid' do
-        it 'redirects to management_consultancy_journey_start_path' do
-          expect(response).to redirect_to management_consultancy_journey_start_path
-        end
+      context 'when the framework is not live' do
+        include_context 'and RM6187 has expired'
 
-        it 'deletes the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to be_nil
-          expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+        it 'renders the unrecognised framework page with the right http status' do
+          post :challenge, params: { challenge_name: 'SMS_MFA', username: username, session: session }
+
+          expect(response).to render_template('home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end

--- a/spec/controllers/supply_teachers/rm6238/admin/passwords_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/admin/passwords_controller_spec.rb
@@ -8,98 +8,149 @@ RSpec.describe SupplyTeachers::RM6238::Admin::PasswordsController do
   let(:default_params) { { service: 'supply_teachers/admin', framework: 'RM6238' } }
 
   describe 'GET new' do
-    before { get :new }
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-    render_views
+        expect(response).to render_template(:new)
+      end
+    end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:new)
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+
+      it 'renders the new page' do
+        get :new
+
+        expect(response).to render_template(:new)
+      end
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
-    context 'when no exception is raised' do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    context 'when the framework is live' do
+      context 'when no exception is raised' do
+        before do
+          post :create, params: { email: email }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the email is invalid' do
+          let(:email) { 'testtest.com' }
+
+          it 'redirects to the supply_teachers_rm6238_admin_new_user_password_path' do
+            expect(response).to redirect_to supply_teachers_rm6238_admin_new_user_password_path
+          end
+
+          it 'does not set the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to be_nil
+          end
+        end
+
+        context 'when the email is valid' do
+          let(:email) { 'test@test.com' }
+
+          it 'redirects to supply_teachers_rm6238_admin_edit_user_password_path' do
+            expect(response).to redirect_to supply_teachers_rm6238_admin_edit_user_password_path
+          end
+
+          it 'sets the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+          end
+        end
+      end
+
+      context 'when the email is valid but an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { email: 'test@test.com' }
+        end
+
+        context 'and the error is UserNotFoundException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
+
+          it 'redirects to the edit password page' do
+            expect(response).to redirect_to supply_teachers_rm6238_admin_edit_user_password_path
+          end
+        end
+
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to supply_teachers_rm6238_admin_new_user_password_path
+          end
+        end
+
+        context 'and the error is ServiceError' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to supply_teachers_rm6238_admin_new_user_password_path
+          end
+        end
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+
       before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: email }
+        post :create, params: { email: 'test@test.com' }
         cookies.update(response.cookies)
       end
 
-      context 'when the email is invalid' do
-        let(:email) { 'testtest.com' }
-
-        it 'redirects to the supply_teachers_rm6238_admin_new_user_password_path' do
-          expect(response).to redirect_to supply_teachers_rm6238_admin_new_user_password_path
-        end
-
-        it 'does not set the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to be_nil
-        end
+      it 'redirects to supply_teachers_rm6238_admin_edit_user_password_path' do
+        expect(response).to redirect_to supply_teachers_rm6238_admin_edit_user_password_path
       end
 
-      context 'when the email is valid' do
-        let(:email) { 'test@test.com' }
-
-        it 'redirects to supply_teachers_rm6238_admin_edit_user_password_path' do
-          expect(response).to redirect_to supply_teachers_rm6238_admin_edit_user_password_path
-        end
-
-        it 'sets the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
-        end
-      end
-    end
-
-    context 'when the email is valid but an exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: 'test@test.com' }
-      end
-
-      context 'and the error is UserNotFoundException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
-
-        it 'redirects to the edit password page' do
-          expect(response).to redirect_to supply_teachers_rm6238_admin_edit_user_password_path
-        end
-      end
-
-      context 'and the error is InvalidParameterException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to supply_teachers_rm6238_admin_new_user_password_path
-        end
-      end
-
-      context 'and the error is ServiceError' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to supply_teachers_rm6238_admin_new_user_password_path
-        end
+      it 'sets the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET edit' do
-    before do
-      cookies[:crown_marketplace_reset_email] = 'test@email.com'
-      get :edit
+    context 'when the framework is live' do
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
     end
 
-    render_views
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
 
-    it 'renders the edit page' do
-      expect(response).to render_template(:edit)
-    end
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
 
-    it 'the email has been set correctly in the response object' do
-      expect(assigns(:response).email).to eq('test@email.com')
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
     end
   end
 
@@ -110,24 +161,46 @@ RSpec.describe SupplyTeachers::RM6238::Admin::PasswordsController do
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
       # rubocop:enable RSpec/AnyInstance
-      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
-      cookies.update(response.cookies)
     end
 
-    context 'when the reset password is invalid' do
-      let(:password) { 'Pas12!' }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+    context 'when the framework is live' do
+      before do
+        put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+        cookies.update(response.cookies)
       end
 
-      it 'does not delete the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      context 'when the reset password is invalid' do
+        let(:password) { 'Pas12!' }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'does not delete the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+        end
+      end
+
+      context 'when the reset password is valid' do
+        let(:password) { 'Password12345!' }
+
+        it 'redirects to supply_teachers_rm6238_admin_password_reset_success_path' do
+          expect(response).to redirect_to supply_teachers_rm6238_admin_password_reset_success_path
+        end
+
+        it 'deletes the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to be_nil
+        end
       end
     end
 
-    context 'when the reset password is valid' do
-      let(:password) { 'Password12345!' }
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+
+      before do
+        put :update, params: { email: 'test@test.com', password: 'Password12345!', password_confirmation: 'Password12345!', confirmation_code: '123456' }
+        cookies.update(response.cookies)
+      end
 
       it 'redirects to supply_teachers_rm6238_admin_password_reset_success_path' do
         expect(response).to redirect_to supply_teachers_rm6238_admin_password_reset_success_path
@@ -140,12 +213,22 @@ RSpec.describe SupplyTeachers::RM6238::Admin::PasswordsController do
   end
 
   describe 'GET password_reset_success' do
-    before { get :password_reset_success }
+    context 'when the framework is live' do
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
 
-    render_views
+        expect(response).to render_template(:password_reset_success)
+      end
+    end
 
-    it 'renders the password_reset_success page' do
-      expect(response).to render_template(:password_reset_success)
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
+
+        expect(response).to render_template(:password_reset_success)
+      end
     end
   end
 end

--- a/spec/controllers/supply_teachers/rm6238/admin/sessions_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/admin/sessions_controller_spec.rb
@@ -10,10 +10,22 @@ RSpec.describe SupplyTeachers::RM6238::Admin::SessionsController do
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'GET new' do
-    it 'renders the new page' do
-      get :new
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-      expect(response).to render_template(:new)
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+
+      it 'renders the new page' do
+        get :new
+
+        expect(response).to render_template(:new)
+      end
     end
   end
 
@@ -114,6 +126,35 @@ RSpec.describe SupplyTeachers::RM6238::Admin::SessionsController do
           expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
           expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
         end
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+      include_context 'with cognito structs'
+
+      let(:username) { user.cognito_uuid }
+      let(:session) { 'I_AM_THE_SESSION' }
+      let(:cognito_groups) do
+        admin_list_groups_for_user_resp_struct.new(
+          groups: [
+            cognito_group_struct.new(group_name: 'ccs_employee'),
+            cognito_group_struct.new(group_name: 'st_access')
+          ]
+        )
+      end
+
+      before do
+        allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: nil, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+
+        post :create, params: { user: { email: email, password: 'Password12345!' } }
+        cookies.update(response.cookies)
+      end
+
+      it 'redirects to supply_teachers_rm6238_admin_uploads_path' do
+        expect(response).to redirect_to supply_teachers_rm6238_admin_uploads_path
       end
     end
   end

--- a/spec/controllers/supply_teachers/rm6238/admin/users_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/admin/users_controller_spec.rb
@@ -10,26 +10,51 @@ RSpec.describe SupplyTeachers::RM6238::Admin::UsersController do
   describe 'GET challenge_new' do
     let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
 
-    before do
-      cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
-      get :challenge_new, params: { challenge_name: challenge_name }
-    end
+    before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
-    render_views
+    context 'when the framework is live' do
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
 
-    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
-      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+      render_views
 
-      it 'renders the new_password_required partial' do
-        expect(response).to render_template(partial: 'base/users/_new_password_required')
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
       end
     end
 
-    context 'when the challenge is SMS_MFA' do
-      let(:challenge_name) { 'SMS_MFA' }
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
 
-      it 'renders the sms_mfa partial' do
-        expect(response).to render_template(partial: 'base/users/_sms_mfa')
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
+
+      render_views
+
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
       end
     end
   end
@@ -58,47 +83,69 @@ RSpec.describe SupplyTeachers::RM6238::Admin::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:password) { 'Pas12!' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
-        end
-      end
+        context 'and it is not valid' do
+          let(:password) { 'Pas12!' }
 
-      context 'and it is valid' do
-        context 'and there is an additional challange' do
-          let(:new_challenge_name) { 'SMS_MFA' }
-
-          it 'redirects to supply_teachers_rm6238_admin_users_challenge_path' do
-            expect(response).to redirect_to supply_teachers_rm6238_admin_users_challenge_path(challenge_name: new_challenge_name)
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
           end
 
-          it 'the cookies are updated correctly' do
-            expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
             expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
           end
         end
 
-        context 'and there is no additional challange' do
-          it 'redirects to supply_teachers_rm6238_admin_uploads_path' do
-            expect(response).to redirect_to supply_teachers_rm6238_admin_uploads_path
+        context 'and it is valid' do
+          context 'and there is an additional challange' do
+            let(:new_challenge_name) { 'SMS_MFA' }
+
+            it 'redirects to supply_teachers_rm6238_admin_users_challenge_path' do
+              expect(response).to redirect_to supply_teachers_rm6238_admin_users_challenge_path(challenge_name: new_challenge_name)
+            end
+
+            it 'the cookies are updated correctly' do
+              expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+              expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+            end
           end
 
-          it 'deletes the cookies' do
-            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
-            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          context 'and there is no additional challange' do
+            it 'redirects to supply_teachers_rm6238_admin_uploads_path' do
+              expect(response).to redirect_to supply_teachers_rm6238_admin_uploads_path
+            end
+
+            it 'deletes the cookies' do
+              expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+              expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+            end
           end
+        end
+      end
+
+      context 'when the framework is not live' do
+        include_context 'and RM6238 has expired'
+
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
+        end
+
+        it 'redirects to supply_teachers_rm6238_admin_uploads_path' do
+          expect(response).to redirect_to supply_teachers_rm6238_admin_uploads_path
+        end
+
+        it 'deletes the cookies' do
+          expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+          expect(cookies[:crown_marketplace_challenge_username]).to be_nil
         end
       end
     end
@@ -112,25 +159,47 @@ RSpec.describe SupplyTeachers::RM6238::Admin::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:access_code) { '123' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        context 'and it is not valid' do
+          let(:access_code) { '123' }
+
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
+          end
+
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+            expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+          end
+        end
+
+        context 'and it is valid' do
+          it 'redirects to supply_teachers_rm6238_admin_uploads_path' do
+            expect(response).to redirect_to supply_teachers_rm6238_admin_uploads_path
+          end
+
+          it 'deletes the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          end
         end
       end
 
-      context 'and it is valid' do
+      context 'when the framework is not live' do
+        include_context 'and RM6238 has expired'
+
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
+        end
+
         it 'redirects to supply_teachers_rm6238_admin_uploads_path' do
           expect(response).to redirect_to supply_teachers_rm6238_admin_uploads_path
         end

--- a/spec/controllers/supply_teachers/rm6238/passwords_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/passwords_controller_spec.rb
@@ -8,98 +8,138 @@ RSpec.describe SupplyTeachers::RM6238::PasswordsController do
   let(:default_params) { { service: 'supply_teachers', framework: 'RM6238' } }
 
   describe 'GET new' do
-    before { get :new }
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-    render_views
+        expect(response).to render_template(:new)
+      end
+    end
 
-    it 'renders the new page' do
-      expect(response).to render_template(:new)
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
-    context 'when no exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: email }
-        cookies.update(response.cookies)
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    context 'when the framework is live' do
+      context 'when no exception is raised' do
+        before do
+          post :create, params: { email: email }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the email is invalid' do
+          let(:email) { 'testtest.com' }
+
+          it 'redirects to the supply_teachers_rm6238_new_user_password_path' do
+            expect(response).to redirect_to supply_teachers_rm6238_new_user_password_path
+          end
+
+          it 'does not set the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to be_nil
+          end
+        end
+
+        context 'when the email is valid' do
+          let(:email) { 'test@test.com' }
+
+          it 'redirects to supply_teachers_rm6238_edit_user_password_path' do
+            expect(response).to redirect_to supply_teachers_rm6238_edit_user_password_path
+          end
+
+          it 'sets the crown_marketplace_reset_email cookie' do
+            expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+          end
+        end
       end
 
-      context 'when the email is invalid' do
-        let(:email) { 'testtest.com' }
-
-        it 'redirects to the supply_teachers_rm6238_new_user_password_path' do
-          expect(response).to redirect_to supply_teachers_rm6238_new_user_password_path
+      context 'when the email is valid but an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { email: 'test@test.com' }
         end
 
-        it 'does not set the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to be_nil
-        end
-      end
+        context 'and the error is UserNotFoundException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
 
-      context 'when the email is valid' do
-        let(:email) { 'test@test.com' }
-
-        it 'redirects to supply_teachers_rm6238_edit_user_password_path' do
-          expect(response).to redirect_to supply_teachers_rm6238_edit_user_password_path
+          it 'redirects to the edit password page' do
+            expect(response).to redirect_to supply_teachers_rm6238_edit_user_password_path
+          end
         end
 
-        it 'sets the crown_marketplace_reset_email cookie' do
-          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to supply_teachers_rm6238_new_user_password_path
+          end
+        end
+
+        context 'and the error is ServiceError' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+          it 'redirects to the new password page' do
+            expect(response).to redirect_to supply_teachers_rm6238_new_user_password_path
+          end
         end
       end
     end
 
-    context 'when the email is valid but an exception is raised' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
-        # rubocop:enable RSpec/AnyInstance
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
         post :create, params: { email: 'test@test.com' }
-      end
 
-      context 'and the error is UserNotFoundException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
-
-        it 'redirects to the edit password page' do
-          expect(response).to redirect_to supply_teachers_rm6238_edit_user_password_path
-        end
-      end
-
-      context 'and the error is InvalidParameterException' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to supply_teachers_rm6238_new_user_password_path
-        end
-      end
-
-      context 'and the error is ServiceError' do
-        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
-
-        it 'redirects to the new password page' do
-          expect(response).to redirect_to supply_teachers_rm6238_new_user_password_path
-        end
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET edit' do
-    before do
-      cookies[:crown_marketplace_reset_email] = 'test@email.com'
-      get :edit
+    context 'when the framework is live' do
+      before do
+        cookies[:crown_marketplace_reset_email] = 'test@email.com'
+        get :edit
+      end
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'the email has been set correctly in the response object' do
+        expect(assigns(:response).email).to eq('test@email.com')
+      end
     end
 
-    render_views
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
 
-    it 'renders the edit page' do
-      expect(response).to render_template(:edit)
-    end
+      it 'renders the unrecognised framework page with the right http status' do
+        get :edit
 
-    it 'the email has been set correctly in the response object' do
-      expect(assigns(:response).email).to eq('test@email.com')
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
@@ -110,42 +150,69 @@ RSpec.describe SupplyTeachers::RM6238::PasswordsController do
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
       allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
       # rubocop:enable RSpec/AnyInstance
-      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
-      cookies.update(response.cookies)
     end
 
-    context 'when the reset password is invalid' do
-      let(:password) { 'Pas12!' }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+    context 'when the framework is live' do
+      before do
+        put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+        cookies.update(response.cookies)
       end
 
-      it 'does not delete the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      context 'when the reset password is invalid' do
+        let(:password) { 'Pas12!' }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'does not delete the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+        end
+      end
+
+      context 'when the reset password is valid' do
+        let(:password) { 'Password12345!' }
+
+        it 'redirects to supply_teachers_rm6238_password_reset_success_path' do
+          expect(response).to redirect_to supply_teachers_rm6238_password_reset_success_path
+        end
+
+        it 'deletes the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to be_nil
+        end
       end
     end
 
-    context 'when the reset password is valid' do
-      let(:password) { 'Password12345!' }
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
 
-      it 'redirects to supply_teachers_rm6238_password_reset_success_path' do
-        expect(response).to redirect_to supply_teachers_rm6238_password_reset_success_path
-      end
+      it 'renders the unrecognised framework page with the right http status' do
+        put :update, params: { email: 'test@test.com', password: 'Password12345!', password_confirmation: 'Password12345', confirmation_code: '123456' }
 
-      it 'deletes the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to be_nil
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
 
   describe 'GET password_reset_success' do
-    before { get :password_reset_success }
+    context 'when the framework is live' do
+      it 'renders the password_reset_success page' do
+        get :password_reset_success
 
-    render_views
+        expect(response).to render_template(:password_reset_success)
+      end
+    end
 
-    it 'renders the password_reset_success page' do
-      expect(response).to render_template(:password_reset_success)
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :password_reset_success
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 end

--- a/spec/controllers/supply_teachers/rm6238/sessions_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/sessions_controller_spec.rb
@@ -10,10 +10,23 @@ RSpec.describe SupplyTeachers::RM6238::SessionsController do
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'GET new' do
-    it 'renders the new page' do
-      get :new
+    context 'when the framework is live' do
+      it 'renders the new page' do
+        get :new
 
-      expect(response).to render_template(:new)
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        get :new
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
@@ -114,6 +127,17 @@ RSpec.describe SupplyTeachers::RM6238::SessionsController do
           expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
           expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
         end
+      end
+    end
+
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
+
+      it 'renders the unrecognised framework page with the right http status' do
+        post :create, params: { user: { email: email, password: 'Password12345!' } }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/controllers/supply_teachers/rm6238/users_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/users_controller_spec.rb
@@ -10,26 +10,38 @@ RSpec.describe SupplyTeachers::RM6238::UsersController do
   describe 'GET challenge_new' do
     let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
 
-    before do
-      cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
-      get :challenge_new, params: { challenge_name: challenge_name }
-    end
+    before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
-    render_views
+    context 'when the framework is live' do
+      before { get :challenge_new, params: { challenge_name: challenge_name } }
 
-    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
-      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+      render_views
 
-      it 'renders the new_password_required partial' do
-        expect(response).to render_template(partial: 'base/users/_new_password_required')
+      context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'renders the new_password_required partial' do
+          expect(response).to render_template(partial: 'base/users/_new_password_required')
+        end
+      end
+
+      context 'when the challenge is SMS_MFA' do
+        let(:challenge_name) { 'SMS_MFA' }
+
+        it 'renders the sms_mfa partial' do
+          expect(response).to render_template(partial: 'base/users/_sms_mfa')
+        end
       end
     end
 
-    context 'when the challenge is SMS_MFA' do
-      let(:challenge_name) { 'SMS_MFA' }
+    context 'when the framework is not live' do
+      include_context 'and RM6238 has expired'
 
-      it 'renders the sms_mfa partial' do
-        expect(response).to render_template(partial: 'base/users/_sms_mfa')
+      it 'renders the unrecognised framework page with the right http status' do
+        get :challenge_new, params: { challenge_name: 'NEW_PASSWORD_REQUIRED' }
+
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -58,47 +70,62 @@ RSpec.describe SupplyTeachers::RM6238::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:password) { 'Pas12!' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
-        end
-      end
+        context 'and it is not valid' do
+          let(:password) { 'Pas12!' }
 
-      context 'and it is valid' do
-        context 'and there is an additional challange' do
-          let(:new_challenge_name) { 'SMS_MFA' }
-
-          it 'redirects to supply_teachers_rm6238_users_challenge_path' do
-            expect(response).to redirect_to supply_teachers_rm6238_users_challenge_path(challenge_name: new_challenge_name)
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
           end
 
-          it 'the cookies are updated correctly' do
-            expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
             expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
           end
         end
 
-        context 'and there is no additional challange' do
-          it 'redirects to supply_teachers_journey_start_path' do
-            expect(response).to redirect_to supply_teachers_journey_start_path
+        context 'and it is valid' do
+          context 'and there is an additional challange' do
+            let(:new_challenge_name) { 'SMS_MFA' }
+
+            it 'redirects to supply_teachers_rm6238_users_challenge_path' do
+              expect(response).to redirect_to supply_teachers_rm6238_users_challenge_path(challenge_name: new_challenge_name)
+            end
+
+            it 'the cookies are updated correctly' do
+              expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+              expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+            end
           end
 
-          it 'deletes the cookies' do
-            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
-            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          context 'and there is no additional challange' do
+            it 'redirects to supply_teachers_journey_start_path' do
+              expect(response).to redirect_to supply_teachers_journey_start_path
+            end
+
+            it 'deletes the cookies' do
+              expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+              expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+            end
           end
+        end
+      end
+
+      context 'when the framework is not live' do
+        include_context 'and RM6238 has expired'
+
+        it 'renders the unrecognised framework page with the right http status' do
+          post :challenge, params: { challenge_name: 'SMS_MFA', username: username, session: session }
+
+          expect(response).to render_template('home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end
@@ -112,32 +139,47 @@ RSpec.describe SupplyTeachers::RM6238::UsersController do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
         allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
-
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
-        cookies.update(response.cookies)
       end
 
-      context 'and it is not valid' do
-        let(:access_code) { '123' }
-
-        it 'renders challenge_new' do
-          expect(response).to render_template(:challenge_new)
+      context 'when the framework is live' do
+        before do
+          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
-          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        context 'and it is not valid' do
+          let(:access_code) { '123' }
+
+          it 'renders challenge_new' do
+            expect(response).to render_template(:challenge_new)
+          end
+
+          it 'does not delete the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+            expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+          end
+        end
+
+        context 'and it is valid' do
+          it 'redirects to supply_teachers_journey_start_path' do
+            expect(response).to redirect_to supply_teachers_journey_start_path
+          end
+
+          it 'deletes the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to be_nil
+            expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+          end
         end
       end
 
-      context 'and it is valid' do
-        it 'redirects to supply_teachers_journey_start_path' do
-          expect(response).to redirect_to supply_teachers_journey_start_path
-        end
+      context 'when the framework is not live' do
+        include_context 'and RM6238 has expired'
 
-        it 'deletes the cookies' do
-          expect(cookies[:crown_marketplace_challenge_session]).to be_nil
-          expect(cookies[:crown_marketplace_challenge_username]).to be_nil
+        it 'renders the unrecognised framework page with the right http status' do
+          post :challenge, params: { challenge_name: 'SMS_MFA', username: username, session: session }
+
+          expect(response).to render_template('home/unrecognised_framework')
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end

--- a/spec/support/framework_status.rb
+++ b/spec/support/framework_status.rb
@@ -6,10 +6,22 @@ RSpec.shared_context 'and RM6238 is live today' do
   before { Framework.find_by(framework: 'RM6238').update(live_at: Time.zone.now) }
 end
 
+RSpec.shared_context 'and RM6238 has expired' do
+  before { Framework.find_by(framework: 'RM6238').update(expires_at: Time.zone.now) }
+end
+
 RSpec.shared_context 'and RM6240 is live in the future' do
   before { Framework.find_by(framework: 'RM6240').update(live_at: 1.day.from_now) }
 end
 
 RSpec.shared_context 'and RM6240 is live today' do
   before { Framework.find_by(framework: 'RM6240').update(live_at: Time.zone.now) }
+end
+
+RSpec.shared_context 'and RM6240 has expired' do
+  before { Framework.find_by(framework: 'RM6240').update(expires_at: Time.zone.now) }
+end
+
+RSpec.shared_context 'and RM6187 has expired' do
+  before { Framework.find_by(framework: 'RM6187').update(expires_at: Time.zone.now) }
 end


### PR DESCRIPTION
Ticket: [FMFR-1357](https://crowncommercialservice.atlassian.net/browse/FMFR-1357)

After doing some work for adding the ability to close FM frameworks in the other repo, I made a change so that the frameworks are validated in the authentication sections of the app.

In this commit I am porting those changes over and updating all the specs accordingly.