### PR TITLE
Remove `@pipeline` tag on feature tests for PRs

### DIFF
--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -33,8 +33,6 @@ jobs:
 
   run-feature-tests:
     uses: ./.github/workflows/feature_tests.yml
-    with:
-      run_all_feature_tests: true
 
   deploy-to-application:
     runs-on: ubuntu-latest

--- a/.github/workflows/feature_tests.yml
+++ b/.github/workflows/feature_tests.yml
@@ -2,12 +2,6 @@ name: "Run application feature tests"
 
 on:
   workflow_call:
-    inputs:
-      run_all_feature_tests:
-        description: 'A trigger to run all the feature tests instead of a subset'
-        default: false
-        required: false
-        type: boolean
 
 jobs:
   feature-test:
@@ -50,9 +44,4 @@ jobs:
         run: bin/rails db:import_test_data
 
       - name: Run feature tests
-        run: bin/rails cucumber:pipeline
-        if: ${{ !inputs.run_all_feature_tests }}
-
-      - name: Run all feature tests
         run: bin/rails cucumber:ok
-        if: ${{ inputs.run_all_feature_tests }}

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -19,5 +19,3 @@ jobs:
 
   run-feature-tests:
     uses: ./.github/workflows/feature_tests.yml
-    with:
-      run_all_feature_tests: ${{ github.event.pull_request.base.ref == 'preview' || github.event.pull_request.base.ref == 'production' }}

--- a/README.md
+++ b/README.md
@@ -184,8 +184,7 @@ To run a specific feature test, use:
 bundle exec cucumber feature/path/to/feature.feature
 ```
 
-For Pull Requests, a subset of the feature tests are run (ones that have the `@pipeline` tag).
-However, all feature tests are run as part of the release process.
+All the feature tests are run as part of the Pull Request and release process.
 
 #### Accessibility testing
 We use [Axe Cucumber][] to run accessibility tests but these are not run as part of the CI.

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -4,10 +4,8 @@ rerun = rerun.strip.gsub /\s/, ' '
 rerun_opts = rerun.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
 std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags 'not @wip and not @accessibility' --publish-quiet "
 accessibility_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags '@accessibility' --publish-quiet "
-pipeline_opts = "--format progress --strict --tags '@pipeline' --publish-quiet"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features --publish-quiet
 rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip'
 accessibility: <%= accessibility_opts %> features/accessibility
-pipeline: <%= pipeline_opts %> features

--- a/features/services/legal_services/responsive_navigation_links.feature
+++ b/features/services/legal_services/responsive_navigation_links.feature
@@ -1,4 +1,4 @@
-@mobile @javascript @pipline
+@mobile @javascript
 Feature: Legal Services - Headers are responsive
 
   Scenario: Signed in and the navigation links are responsive

--- a/features/services/legal_services/rm6240/cognito/forgot_password.feature
+++ b/features/services/legal_services/rm6240/cognito/forgot_password.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Forgot my password - Legal Services - RM6240
 
   Scenario: I forgot my password

--- a/features/services/legal_services/rm6240/cognito/sign_in.feature
+++ b/features/services/legal_services/rm6240/cognito/sign_in.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Sign in to my account - Legal Services - RM6240
 
   Background: Navigate to the sign in page

--- a/features/services/legal_services/rm6240/cognito/sign_up_user.feature
+++ b/features/services/legal_services/rm6240/cognito/sign_up_user.feature
@@ -1,4 +1,4 @@
-@allow_list @pipeline
+@allow_list
 Feature: Sign up to legal services - RM6240
 
   Scenario: I sign in to my existing account

--- a/features/services/legal_services/rm6240/cognito/validations/forgot_password_validations.feature
+++ b/features/services/legal_services/rm6240/cognito/validations/forgot_password_validations.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Forgot my password - Legal Services - RM6240 - Validations
 
   Background: Navigate to forgot password

--- a/features/services/legal_services/rm6240/cognito/validations/sign_in_validation.feature
+++ b/features/services/legal_services/rm6240/cognito/validations/sign_in_validation.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Sign in to my account - Legal Services - RM6240 - Validations
 
   Background: Navigate to the sign in page

--- a/features/services/legal_services/rm6240/cognito/validations/sign_up_user_validations.feature
+++ b/features/services/legal_services/rm6240/cognito/validations/sign_up_user_validations.feature
@@ -1,4 +1,4 @@
-@allow_list @pipeline
+@allow_list
 Feature: Sign up user - Legal Services - RM6240 - Validations
 
   Background: navigate to create an account page

--- a/features/services/legal_services/rm6240/home/cookie_settings.feature
+++ b/features/services/legal_services/rm6240/home/cookie_settings.feature
@@ -1,4 +1,4 @@
-@javascript @pipeline
+@javascript
 Feature: Legal Services - Cookie settings
 
   Background: Go to start page

--- a/features/services/legal_services/rm6240/home/start_pages.feature
+++ b/features/services/legal_services/rm6240/home/start_pages.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal Services - Start pages
 
   Scenario: Buyer sees start page

--- a/features/services/legal_services/rm6240/home/validations/sign_up_user_validations.feature
+++ b/features/services/legal_services/rm6240/home/validations/sign_up_user_validations.feature
@@ -1,4 +1,4 @@
-@allow_list @pipeline
+@allow_list
 Feature: Legal Services - Sign up user
 
   Background: navigate to create an account page

--- a/features/services/legal_services/rm6240/journey/central_government/lot_1/restults.feature
+++ b/features/services/legal_services/rm6240/journey/central_government/lot_1/restults.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal services -  Central governemnt - Lot 1 - Results
 
   Background: Navigate to start page and complete the journey

--- a/features/services/legal_services/rm6240/journey/central_government/lot_1/service_selection.feature
+++ b/features/services/legal_services/rm6240/journey/central_government/lot_1/service_selection.feature
@@ -1,4 +1,4 @@
-@javascript @pipeline
+@javascript
 Feature: Legal services - Central governemnt - Lot 1 - Service selection
 
   Background: Navigate to start page and select the lot

--- a/features/services/legal_services/rm6240/journey/central_government/lot_1/suppliers.feature
+++ b/features/services/legal_services/rm6240/journey/central_government/lot_1/suppliers.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal services -  Central governemnt - Lot 1 - Suppliers
 
   Background: Navigate to start page and complete the journey

--- a/features/services/legal_services/rm6240/journey/central_government/lot_2/restults.feature
+++ b/features/services/legal_services/rm6240/journey/central_government/lot_2/restults.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal services -  Central governemnt - Lot 2 - Results
 
   Background: Navigate to start page and complete the journey

--- a/features/services/legal_services/rm6240/journey/central_government/lot_2/service_selection.feature
+++ b/features/services/legal_services/rm6240/journey/central_government/lot_2/service_selection.feature
@@ -15,7 +15,6 @@ Feature: Legal services - Central governemnt - Lot 2 - Service selection
     Then I am on the 'Select the legal services you need' page
     And the sub title is 'Lot 2 - General service provision'
 
-  @pipeline
   Scenario: The correct options are available
     Then I should see the following options for the lot:
       | Child Law                       |

--- a/features/services/legal_services/rm6240/journey/central_government/lot_2/suppliers.feature
+++ b/features/services/legal_services/rm6240/journey/central_government/lot_2/suppliers.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal services -  Central governemnt - Lot 2 - Suppliers
 
   Background: Navigate to start page and complete the journey

--- a/features/services/legal_services/rm6240/journey/central_government/lot_3/suppliers.feature
+++ b/features/services/legal_services/rm6240/journey/central_government/lot_3/suppliers.feature
@@ -24,7 +24,6 @@ Feature: Legal services -  Central governemnt - Lot 3 - Suppliers
       | ZEMLAK INC                        |
       | ZIEME GROUP                       |
 
-  @pipeline
   Scenario: Check the supplier data - SME
     Given I click on 'WITTING-OLSON'
     Then I am on the 'WITTING-OLSON' page
@@ -42,7 +41,6 @@ Feature: Legal services -  Central governemnt - Lot 3 - Suppliers
       | http://cremin.org/drema       |
       | 815 Terrell Rest, New Hattiefurt, WV 89027-7230 |
 
-  @pipeline
   Scenario: Check the supplier data - Non SME
     Given I click on 'JACOBSON-NIENOW'
     Then I am on the 'JACOBSON-NIENOW' page

--- a/features/services/legal_services/rm6240/journey/central_government/panel_not_suitable.feature
+++ b/features/services/legal_services/rm6240/journey/central_government/panel_not_suitable.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal services - Central governemnt - fees over £20,000
 
   Scenario: If my requirements are not suitable, I cannot continue

--- a/features/services/legal_services/rm6240/journey/non_central_government/lot_1/restults.feature
+++ b/features/services/legal_services/rm6240/journey/non_central_government/lot_1/restults.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal services - Non central governemnt - Lot 1 - Results
 
   Background: Navigate to start page and complete the journey

--- a/features/services/legal_services/rm6240/journey/non_central_government/lot_1/service_selection.feature
+++ b/features/services/legal_services/rm6240/journey/non_central_government/lot_1/service_selection.feature
@@ -12,7 +12,6 @@ Feature: Legal services - Non central governemnt - Lot 1 - Service selection
     Then I am on the 'Select the legal services you need' page
     And the sub title is 'Lot 1 - Full service provision'
 
-  @pipeline
   Scenario: The correct options are available
     Then I should see the following options for the lot:
       | Administrative and Public Law                   |

--- a/features/services/legal_services/rm6240/journey/non_central_government/lot_1/suppliers.feature
+++ b/features/services/legal_services/rm6240/journey/non_central_government/lot_1/suppliers.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal services - Non central governemnt - Lot 1 - Suppliers
 
   Background: Navigate to start page and complete the journey

--- a/features/services/legal_services/rm6240/journey/non_central_government/lot_2/restults.feature
+++ b/features/services/legal_services/rm6240/journey/non_central_government/lot_2/restults.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal services - Non central governemnt - Lot 2 - Results
 
   Background: Navigate to start page and complete the journey

--- a/features/services/legal_services/rm6240/journey/non_central_government/lot_2/service_selection.feature
+++ b/features/services/legal_services/rm6240/journey/non_central_government/lot_2/service_selection.feature
@@ -1,4 +1,4 @@
-@javascript @pipeline
+@javascript
 Feature: Legal services - Non central governemnt - Lot 2 - Service selection
 
   Background: Navigate to start page and select the lot

--- a/features/services/legal_services/rm6240/journey/non_central_government/lot_2/suppliers.feature
+++ b/features/services/legal_services/rm6240/journey/non_central_government/lot_2/suppliers.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal services - Non central governemnt - Lot 2 - Suppliers
 
   Background: Navigate to start page and complete the journey

--- a/features/services/legal_services/rm6240/journey/non_central_government/lot_3/suppliers.feature
+++ b/features/services/legal_services/rm6240/journey/non_central_government/lot_3/suppliers.feature
@@ -21,7 +21,6 @@ Feature: Legal services - Non central governemnt - Lot 3 - Suppliers
       | ZEMLAK INC                        |
       | ZIEME GROUP                       |
 
-  @pipeline
   Scenario: Check the supplier data - SME
     Given I click on 'WITTING-OLSON'
     Then I am on the 'WITTING-OLSON' page
@@ -39,7 +38,6 @@ Feature: Legal services - Non central governemnt - Lot 3 - Suppliers
       | http://cremin.org/drema       |
       | 815 Terrell Rest, New Hattiefurt, WV 89027-7230 |
 
-  @pipeline
   Scenario: Check the supplier data - Non SME
     Given I click on 'JACOBSON-NIENOW'
     Then I am on the 'JACOBSON-NIENOW' page

--- a/features/services/legal_services/rm6240/journey/validations/journey_validations.feature
+++ b/features/services/legal_services/rm6240/journey/validations/journey_validations.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal services - Jounrey validations
 
   Background: Navigate to start page

--- a/features/services/legal_services/unrecognised_framework.feature
+++ b/features/services/legal_services/unrecognised_framework.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Legal Services - Start pages - With an unrecognised framework
 
   Scenario Outline: Go to unrecognised famework in the buyer section - logged in

--- a/features/services/management_consultancy/responsive_navigation_links.feature
+++ b/features/services/management_consultancy/responsive_navigation_links.feature
@@ -1,4 +1,4 @@
-@mobile @javascript @pipline
+@mobile @javascript
 Feature: Management Consultancy - Headers are responsive
 
   Scenario: Signed in and the navigation links are responsive

--- a/features/services/management_consultancy/rm6187/cognito/forgot_password.feature
+++ b/features/services/management_consultancy/rm6187/cognito/forgot_password.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Forgot my password - Management Consultancy - RM6187
 
   Scenario: I forgot my password

--- a/features/services/management_consultancy/rm6187/cognito/sign_in.feature
+++ b/features/services/management_consultancy/rm6187/cognito/sign_in.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Sign in to my account - Management Consultancy - RM6187
 
   Background: Navigate to the sign in page

--- a/features/services/management_consultancy/rm6187/cognito/sign_up_user.feature
+++ b/features/services/management_consultancy/rm6187/cognito/sign_up_user.feature
@@ -1,4 +1,4 @@
-@allow_list @pipeline
+@allow_list
 Feature: Sign up to management consultancy - RM6187
 
   Scenario: I sign in to my existing account

--- a/features/services/management_consultancy/rm6187/cognito/validations/forgot_password_validations.feature
+++ b/features/services/management_consultancy/rm6187/cognito/validations/forgot_password_validations.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Forgot my password - Management Consultancy - RM6187 - Validations
 
   Background: Navigate to forgot password

--- a/features/services/management_consultancy/rm6187/cognito/validations/sign_in_validation.feature
+++ b/features/services/management_consultancy/rm6187/cognito/validations/sign_in_validation.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Sign in to my account - Management Consultancy - RM6187 - Validations
 
   Background: Navigate to the sign in page

--- a/features/services/management_consultancy/rm6187/cognito/validations/sign_up_user_validations.feature
+++ b/features/services/management_consultancy/rm6187/cognito/validations/sign_up_user_validations.feature
@@ -1,4 +1,4 @@
-@allow_list @pipeline
+@allow_list
 Feature: Sign up user - Management Consultancy - RM6187 - Validations
 
   Background: navigate to create an account page

--- a/features/services/management_consultancy/rm6187/home/cookie_settings.feature
+++ b/features/services/management_consultancy/rm6187/home/cookie_settings.feature
@@ -1,4 +1,4 @@
-@javascript @pipeline
+@javascript
 Feature: Management Consultancy - Cookie settings
 
   Background: Go to start page

--- a/features/services/management_consultancy/rm6187/home/start_pages.feature
+++ b/features/services/management_consultancy/rm6187/home/start_pages.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Management Consultancy - Start pages
 
   Scenario: Buyer sees start page

--- a/features/services/management_consultancy/rm6187/home/validations/sign_up_user_validations.feature
+++ b/features/services/management_consultancy/rm6187/home/validations/sign_up_user_validations.feature
@@ -1,4 +1,4 @@
-@allow_list @pipeline
+@allow_list
 Feature: Management Consultancy - Sign up user
 
   Background: navigate to create an account page

--- a/features/services/management_consultancy/rm6187/journey/results/lot_1.feature
+++ b/features/services/management_consultancy/rm6187/journey/results/lot_1.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Management Consultancy - Lot 1 - Business - Results
 
   Background: Navigate to start page and select the lot

--- a/features/services/management_consultancy/rm6187/journey/results/lot_2.feature
+++ b/features/services/management_consultancy/rm6187/journey/results/lot_2.feature
@@ -17,7 +17,6 @@ Feature: Management Consultancy - Lot 2 - Strategy and Policy - Results
       | VEUM-RODRIGUEZ                |
       | WILLIAMSON, DOYLE AND GLOVER  |
 
-  @pipeline
   Scenario: Service selection changes the results
     Given I click on the 'Back' back link
     Then I am on the 'Select the services you need' page

--- a/features/services/management_consultancy/rm6187/journey/results/lot_3.feature
+++ b/features/services/management_consultancy/rm6187/journey/results/lot_3.feature
@@ -18,7 +18,6 @@ Feature: Management Consultancy - Lot 3 - Complex and Transformation - Results
       | VEUM-RODRIGUEZ                |
       | WILLIAMSON, DOYLE AND GLOVER  |
 
-  @pipeline
   Scenario: Service selection changes the results
     Given I click on the 'Back' back link
     Then I am on the 'Select the services you need' page

--- a/features/services/management_consultancy/rm6187/journey/results/lot_4.feature
+++ b/features/services/management_consultancy/rm6187/journey/results/lot_4.feature
@@ -17,7 +17,6 @@ Feature: Management Consultancy - Lot 4 - Finance - Results
       | VEUM-RODRIGUEZ                |
       | WILLIAMSON, DOYLE AND GLOVER  |
 
-  @pipeline
   Scenario: Service selection changes the results
     Given I click on the 'Back' back link
     Then I am on the 'Select the services you need' page

--- a/features/services/management_consultancy/rm6187/journey/results/lot_5.feature
+++ b/features/services/management_consultancy/rm6187/journey/results/lot_5.feature
@@ -17,7 +17,6 @@ Feature: Management Consultancy - Lot 5 - HR - Results
       | VEUM-RODRIGUEZ                |
       | WILLIAMSON, DOYLE AND GLOVER  |
 
-  @pipeline
   Scenario: Service selection changes the results
     Given I click on the 'Back' back link
     Then I am on the 'Select the services you need' page

--- a/features/services/management_consultancy/rm6187/journey/results/lot_6.feature
+++ b/features/services/management_consultancy/rm6187/journey/results/lot_6.feature
@@ -17,7 +17,6 @@ Feature: Management Consultancy - Lot 6 - Procurement and Supply Chain - Results
       | VEUM-RODRIGUEZ                |
       | WILLIAMSON, DOYLE AND GLOVER  |
 
-  @pipeline
   Scenario: Service selection changes the results
     Given I click on the 'Back' back link
     Then I am on the 'Select the services you need' page

--- a/features/services/management_consultancy/rm6187/journey/results/lot_7.feature
+++ b/features/services/management_consultancy/rm6187/journey/results/lot_7.feature
@@ -17,7 +17,6 @@ Feature: Management Consultancy - Lot 7 - Health, Social Care and Community - Re
       | VEUM-RODRIGUEZ                |
       | WILLIAMSON, DOYLE AND GLOVER  |
 
-  @pipeline
   Scenario: Service selection changes the results
     Given I click on the 'Back' back link
     Then I am on the 'Select the services you need' page

--- a/features/services/management_consultancy/rm6187/journey/results/lot_8.feature
+++ b/features/services/management_consultancy/rm6187/journey/results/lot_8.feature
@@ -17,7 +17,6 @@ Feature: Management Consultancy - Lot 8 - Infrastructure including Transport - R
       | VEUM-RODRIGUEZ                |
       | WILLIAMSON, DOYLE AND GLOVER  |
 
-  @pipeline
   Scenario: Service selection changes the results
     Given I click on the 'Back' back link
     Then I am on the 'Select the services you need' page

--- a/features/services/management_consultancy/rm6187/journey/results/lot_9.feature
+++ b/features/services/management_consultancy/rm6187/journey/results/lot_9.feature
@@ -18,7 +18,6 @@ Feature: Management Consultancy - Lot 9 - Environmental Sustainability and Socio
       | VEUM-RODRIGUEZ                |
       | WILLIAMSON, DOYLE AND GLOVER  |
 
-  @pipeline
   Scenario: Service selection changes the results
     Given I click on the 'Back' back link
     Then I am on the 'Select the services you need' page

--- a/features/services/management_consultancy/rm6187/journey/service_selection/lot_1.feature
+++ b/features/services/management_consultancy/rm6187/journey/service_selection/lot_1.feature
@@ -1,4 +1,4 @@
-@javascript @pipeline
+@javascript
 Feature: Management Consultancy - Lot 1 - Business - Service selection
 
   Background: Navigate to start page and select the lot

--- a/features/services/management_consultancy/rm6187/journey/service_selection/lot_2.feature
+++ b/features/services/management_consultancy/rm6187/journey/service_selection/lot_2.feature
@@ -10,7 +10,6 @@ Feature: Management Consultancy - Lot 2 - Strategy and Policy - Service selectio
     Then I am on the 'Select the services you need' page
     And the sub title is 'MCF3 lot 2 - Strategy and Policy'
 
-  @pipeline
   Scenario: The correct options are available
     Then I should see the following options for the lot:
       | Business structure              |
@@ -23,7 +22,6 @@ Feature: Management Consultancy - Lot 2 - Strategy and Policy - Service selectio
       | Social value                    |
       | Strategic advice                |
 
-  @pipeline
   Scenario: Service selection appears in basked
     Then the basket should say 'No services selected'
     And the remove all link should not be visible

--- a/features/services/management_consultancy/rm6187/journey/service_selection/lot_3.feature
+++ b/features/services/management_consultancy/rm6187/journey/service_selection/lot_3.feature
@@ -10,7 +10,6 @@ Feature: Management Consultancy - Lot 3 - Complex and Transformation - Service s
     Then I am on the 'Select the services you need' page
     And the sub title is 'MCF3 lot 3 - Complex and Transformation'
   
-  @pipeline
   Scenario: The correct options are available
     Then I should see the following options for the lot:
       | Business                            |
@@ -53,7 +52,6 @@ Feature: Management Consultancy - Lot 3 - Complex and Transformation - Service s
       | Supplier side services and delivery |
       | Transformation management.          |
 
-  @pipeline
   Scenario: Changing the selection will change the basket
     When I check the following items:
       | Change management                   |

--- a/features/services/management_consultancy/rm6187/journey/service_selection/lot_4.feature
+++ b/features/services/management_consultancy/rm6187/journey/service_selection/lot_4.feature
@@ -10,7 +10,6 @@ Feature: Management Consultancy - Lot 4 - Finance - Service selection
     Then I am on the 'Select the services you need' page
     And the sub title is 'MCF3 lot 4 - Finance'
   
-  @pipeline
   Scenario: The correct options are available
     Then I should see the following options for the lot:
       | Actuarial services                                        |
@@ -139,7 +138,6 @@ Feature: Management Consultancy - Lot 4 - Finance - Service selection
     When I click on 'Remove all'
     Then the basket should say 'No services selected'
 
-  @pipeline
   Scenario: Go back from supplier results and change selection
     When I check the following items:
       | Business analysis                                         |

--- a/features/services/management_consultancy/rm6187/journey/service_selection/lot_5.feature
+++ b/features/services/management_consultancy/rm6187/journey/service_selection/lot_5.feature
@@ -10,7 +10,6 @@ Feature: Management Consultancy - Lot 5 - HR - Service selection
     Then I am on the 'Select the services you need' page
     And the sub title is 'MCF3 lot 5 - HR'
   
-  @pipeline
   Scenario: The correct options are available
     Then I should see the following options for the lot:
       | Capability development                          |
@@ -24,7 +23,6 @@ Feature: Management Consultancy - Lot 5 - HR - Service selection
       | Organisational design and/or workforce planning |
       | Performance management                          |
 
-  @pipeline
   Scenario: Service selection appears in basked
     Then the basket should say 'No services selected'
     And the remove all link should not be visible

--- a/features/services/management_consultancy/rm6187/journey/service_selection/lot_6.feature
+++ b/features/services/management_consultancy/rm6187/journey/service_selection/lot_6.feature
@@ -10,7 +10,6 @@ Feature: Management Consultancy - Lot 6 - Procurement and Supply Chain - Service
     Then I am on the 'Select the services you need' page
     And the sub title is 'MCF3 lot 6 - Procurement and Supply Chain'
   
-  @pipeline
   Scenario: The correct options are available
     Then I should see the following options for the lot:
       | Category management             |
@@ -53,7 +52,6 @@ Feature: Management Consultancy - Lot 6 - Procurement and Supply Chain - Service
       | Supply chain and logistics      |
       | Tender development and analysis |
 
-  @pipeline
   Scenario: Changing the selection will change the basket
     When I check the following items:
       | Category management         |

--- a/features/services/management_consultancy/rm6187/journey/service_selection/lot_7.feature
+++ b/features/services/management_consultancy/rm6187/journey/service_selection/lot_7.feature
@@ -10,7 +10,6 @@ Feature: Management Consultancy - Lot 7 - Health, Social Care and Community - Se
     Then I am on the 'Select the services you need' page
     And the sub title is 'MCF3 lot 7 - Health, Social Care and Community'
   
-  @pipeline
   Scenario: The correct options are available
     Then I should see the following options for the lot:
       | Alternative delivery models                                 |
@@ -124,7 +123,6 @@ Feature: Management Consultancy - Lot 7 - Health, Social Care and Community - Se
     When I click on 'Remove all'
     Then the basket should say 'No services selected'
 
-  @pipeline
   Scenario: Go back from supplier results and change selection
     When I check the following items:
       | Business case development                       |

--- a/features/services/management_consultancy/rm6187/journey/service_selection/lot_8.feature
+++ b/features/services/management_consultancy/rm6187/journey/service_selection/lot_8.feature
@@ -10,7 +10,6 @@ Feature: Management Consultancy - Lot 8 - Infrastructure including Transport - S
     Then I am on the 'Select the services you need' page
     And the sub title is 'MCF3 lot 8 - Infrastructure including Transport'
   
-  @pipeline
   Scenario: The correct options are available
     Then I should see the following options for the lot:
       | Aviation                                        |
@@ -22,7 +21,6 @@ Feature: Management Consultancy - Lot 8 - Infrastructure including Transport - S
       | Smart infrastructure                            |
       | Towns and cities                                |
 
-  @pipeline
   Scenario: Service selection appears in basked
     Then the basket should say 'No services selected'
     And the remove all link should not be visible

--- a/features/services/management_consultancy/rm6187/journey/service_selection/lot_9.feature
+++ b/features/services/management_consultancy/rm6187/journey/service_selection/lot_9.feature
@@ -10,7 +10,6 @@ Feature: Management Consultancy - Lot 9 - Environmental Sustainability and Socio
     Then I am on the 'Select the services you need' page
     And the sub title is 'MCF3 lot 9 - Environmental Sustainability and Socio-economic Development'
   
-  @pipeline
   Scenario: The correct options are available
     Then I should see the following options for the lot:
       | Air quality                                   |
@@ -65,7 +64,6 @@ Feature: Management Consultancy - Lot 9 - Environmental Sustainability and Socio
       | Social value                                  |
       | Sustainability                                |
 
-  @pipeline
   Scenario: Changing the selection will change the basket
     When I check the following items:
       | Air quality                                   |

--- a/features/services/management_consultancy/rm6187/journey/suppliers.feature
+++ b/features/services/management_consultancy/rm6187/journey/suppliers.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Management Consultancy - Suppliers
 
   Background: Login and then navigate to the supplier results page

--- a/features/services/management_consultancy/rm6187/journey/validations/journey_validations.feature
+++ b/features/services/management_consultancy/rm6187/journey/validations/journey_validations.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Management Consultancy - Jounrey validations
 
   Background: Navigate to start page

--- a/features/services/management_consultancy/unrecognised_framework.feature
+++ b/features/services/management_consultancy/unrecognised_framework.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Management Consultancy - Start pages - With an unrecognised framework
 
   Scenario: Go to unrecognised famework in the buyer section - logged in

--- a/features/services/supply_teachers/responsive_navigation_links.feature
+++ b/features/services/supply_teachers/responsive_navigation_links.feature
@@ -1,4 +1,4 @@
-@mobile @javascript @pipline
+@mobile @javascript
 Feature: Supply Teachers - Headers are responsive
 
   Scenario: Signed in and the navigation links are responsive

--- a/features/services/supply_teachers/rm6238/cognito/forgot_password.feature
+++ b/features/services/supply_teachers/rm6238/cognito/forgot_password.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Forgot my password - Supply Teachers - RM6238
 
   Scenario: I forgot my password

--- a/features/services/supply_teachers/rm6238/cognito/sign_in.feature
+++ b/features/services/supply_teachers/rm6238/cognito/sign_in.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Sign in to my account - Supply Teachers - RM6238
 
   Background: Navigate to the sign in page

--- a/features/services/supply_teachers/rm6238/cognito/validations/forgot_password_validations.feature
+++ b/features/services/supply_teachers/rm6238/cognito/validations/forgot_password_validations.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Forgot my password - Supply Teachers - RM6238 - Validations
 
   Background: Navigate to forgot password

--- a/features/services/supply_teachers/rm6238/cognito/validations/sign_in_validation.feature
+++ b/features/services/supply_teachers/rm6238/cognito/validations/sign_in_validation.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Sign in to my account - Supply Teachers - RM6238 - Validations
 
   Background: Navigate to the sign in page

--- a/features/services/supply_teachers/rm6238/home/cookie_settings.feature
+++ b/features/services/supply_teachers/rm6238/home/cookie_settings.feature
@@ -1,4 +1,4 @@
-@javascript @pipeline
+@javascript
 Feature: Supply Teachers - Cookie settings
 
   Background: Go to start page

--- a/features/services/supply_teachers/rm6238/home/start_pages.feature
+++ b/features/services/supply_teachers/rm6238/home/start_pages.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - Start pages
 
   Scenario: Buyer sees start page

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/agency_payroll/results_by_length.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/agency_payroll/results_by_length.feature
@@ -35,7 +35,6 @@ Feature: Supply Teachers - Agency results - Agency payroll - Results by length
       | Job type: Teacher: (Incl. Qualified and Unqualified Teachers, Tutors) |
       | Term: Daily Supply                                                    |
 
-  @pipeline
   Scenario: The Long Term (6 weeks+) has the correct rates
     And I select 'Long Term (6 weeks+)'
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/agency_payroll/results_by_location.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/agency_payroll/results_by_location.feature
@@ -14,7 +14,7 @@ Feature: Supply Teachers - Agency results - Agency payroll - Results by location
     And I select 'Teacher: (Incl. Qualified and Unqualified Teachers, Tutors)'
     And I select 'Daily Supply'
 
-  @geocode_london @pipeline
+  @geocode_london
   Scenario: London postcode results
     And I enter 'SW1A 1AA' for the 'postcode'
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/agency_payroll/results_by_role.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/agency_payroll/results_by_role.feature
@@ -15,7 +15,6 @@ Feature: Supply Teachers - Agency results - Agency payroll - Results by role
     And I select 'Daily Supply'
     And I enter 'SW1A 1AA' for the 'postcode'
 
-  @pipeline
   Scenario: When the role is Teacher: (Incl. Qualified and Unqualified Teachers, Tutors)
     And I select 'Teacher: (Incl. Qualified and Unqualified Teachers, Tutors)'
     And I click on 'Continue'
@@ -55,7 +54,6 @@ Feature: Supply Teachers - Agency results - Agency payroll - Results by role
       | Job type: Educational Support Staff: (incl. Cover Supervisor, Teaching Assistants)  |
       | Term: Daily Supply                                                                  |
 
-  @pipeline
   Scenario: When the role is Senior Roles: Headteacher and Senior Leadership positions
     And I select 'Senior Roles: Headteacher and Senior Leadership positions'
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/agency_payroll/suppliers.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/agency_payroll/suppliers.feature
@@ -18,7 +18,6 @@ Feature: Supply Teachers - Agency results - Agency payroll - Agencies
     And I click on 'Continue'
     Then I am on the 'Agency results' page
 
-  @pipeline
   Scenario: The agency details shown are correct
     And there are 5 agencies
     And the listed agencies with rates and distances are:
@@ -40,7 +39,6 @@ Feature: Supply Teachers - Agency results - Agency payroll - Agencies
     | KERLUKE, TORP AND HEATHCOTE   | Liverpool |
     | FEEST-MULLER                  | Liverpool |
 
-  @pipeline
   Scenario: I can download the shortlist document
     And I click on 'Download shortlist of agencies'
     Then the spreadsheet 'Shortlist of agencies' is downloaded

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/daily_rate.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/daily_rate.feature
@@ -1,4 +1,4 @@
-@pipeline @javascript @geocode_liverpool
+@javascript @geocode_liverpool
 Feature: Supply Teachers - Agency results - Fixed term - Daily rate
 
   Background: Navigate to the Agency results page

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/results_by_length.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/results_by_length.feature
@@ -13,7 +13,6 @@ Feature: Supply Teachers - Agency results - Fixed term - Results by length
     And I click on 'Continue'
     Then I am on the 'What date do you want the employee to start?' page
 
-  @pipeline
   Scenario Outline: Changing the length of the contract changes the result values only
     And I enter '06/05/2022' for the date
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/results_by_location.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/results_by_location.feature
@@ -105,7 +105,7 @@ Feature: Supply Teachers - Agency results - Fixed term - Results by location
       | Postcode: SW1A 1AA              |
       | Search distance: 50 miles       |
 
-  @geocode_liverpool @pipeline
+  @geocode_liverpool
   Scenario: Liverpool postcode results
     And I enter 'L3 4AA' for the 'postcode'
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/results_by_salary.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/results_by_salary.feature
@@ -1,4 +1,4 @@
-@pipeline @geocode_liverpool
+@geocode_liverpool
 Feature: Supply Teachers - Agency results - Fixed term - Results by length
 
   Scenario Outline: Changing the salary of the contract changes the result values only

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/suppliers.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/fixed_term/suppliers.feature
@@ -25,7 +25,6 @@ Feature: Supply Teachers - Agency results - Fixed term - Agencies
     And I click on 'Continue'
     Then I am on the 'Agency results' page
   
-  @pipeline
   Scenario: The agency details shown are correct
     And there are 8 agencies
     And the listed agencies with distances, fees and lengths are:
@@ -38,7 +37,6 @@ Feature: Supply Teachers - Agency results - Fixed term - Agencies
       | EMARD AND SONS                | Twickenham  | 9.0 | 28000 | 3 months  | £2,450.70 | 35.0% |
       | FEEST-MULLER                  | London      | 0.2 | 28000 | 3 months  | £2,501.10 | 35.7% |
 
-  @pipeline
   Scenario Outline: I can naviagte to the agency details
     Given I click on '<agency_name>'
     Then I am on the '<agency_name>' page
@@ -51,7 +49,6 @@ Feature: Supply Teachers - Agency results - Fixed term - Agencies
     | DIETRICH-BORER                | London      |
     | EMARD AND SONS                | Twickenham  |
 
-  @pipeline
   Scenario: I can download the shortlist document
     And I click on 'Download shortlist of agencies'
     Then the spreadsheet 'Shortlist of agencies' is downloaded

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/nominated_worker/results_by_location.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/nominated_worker/results_by_location.feature
@@ -9,7 +9,7 @@ Feature: Supply Teachers - Agency results - Nominated worker - Results by locati
     And I click on 'Continue'
     Then I am on the 'What is your school’s postcode?' page
 
-  @geocode_london @pipeline
+  @geocode_london
   Scenario: London postcode results
     And I enter 'SW1A 1AA' for the 'postcode'
     And I click on 'Continue'
@@ -167,7 +167,7 @@ Feature: Supply Teachers - Agency results - Nominated worker - Results by locati
       | Postcode: L3 4AA                |
       | Search distance: 50 miles       |
 
-  @geocode_birmingham @pipeline
+  @geocode_birmingham
   Scenario: Birmingham postcode results
     And I enter 'B6 6HE' for the 'postcode'
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/agency_results/nominated_worker/suppliers.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/agency_results/nominated_worker/suppliers.feature
@@ -13,7 +13,6 @@ Feature: Supply Teachers - Agency results - Nominated worker - Agencies
     And I click on 'Continue'
     Then I am on the 'Agency results' page
   
-  @pipeline
   Scenario: The agency details shown are correct
     And there are 8 agencies
     And the listed agencies with rates and distances are:
@@ -38,7 +37,6 @@ Feature: Supply Teachers - Agency results - Nominated worker - Agencies
       | HAGENES-BECHTELAR | London  |
       | FEEST-MULLER      | London  |
 
-  @pipeline
   Scenario: I can download the shortlist document
     And I click on 'Download shortlist of agencies'
     Then the spreadsheet 'Shortlist of agencies' is downloaded

--- a/features/services/supply_teachers/rm6238/jounrey/all_agencies/results.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/all_agencies/results.feature
@@ -1,4 +1,4 @@
-@pipeline @javascript
+@javascript
 Feature: Supply Teachers - All agencies
 
   Scenario: All agencies search

--- a/features/services/supply_teachers/rm6238/jounrey/all_agencies/suppliers.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/all_agencies/suppliers.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - All agencies - suppliers
 
   Background: Navigate to the All agencies page 

--- a/features/services/supply_teachers/rm6238/jounrey/education_technology_platforms/education_technology_platforms.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/education_technology_platforms/education_technology_platforms.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - Education technology platforms
 
   Scenario: Education technology platform results

--- a/features/services/supply_teachers/rm6238/jounrey/fta_to_perm/journeys.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/fta_to_perm/journeys.feature
@@ -6,7 +6,6 @@ Feature: Supply Teachers - FTA to perm - results
     And I click on 'Continue'
     Then I am on the 'What date did the workers fixed term contract start?' page
 
-  @pipeline
   Scenario: Contract ended within 6 months and the length is more then tweleve months
     And I enter a date 1 years and 2 months into the past
     And I click on 'Continue'
@@ -58,7 +57,6 @@ Feature: Supply Teachers - FTA to perm - results
     And I click on 'Check another fixed term contract'
     And I am on the 'What date did the workers fixed term contract start?' page
 
-  @pipeline
   Scenario: I can view the rate at which I will be charged
     And I enter a date 0 years and 6 months into the past
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/fta_to_perm/results.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/fta_to_perm/results.feature
@@ -6,7 +6,6 @@ Feature: Supply Teachers - FTA to perm - results
     And I click on 'Continue'
     Then I am on the 'What date did the workers fixed term contract start?' page
 
-  @pipeline
   Scenario Outline: Changing the rate changes the results
     And I enter a date 0 years and 6 months into the past
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/master_vendor/master_vendor_above_threshold.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/master_vendor/master_vendor_above_threshold.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - Master vendors - Above threshold
 
   Scenario: Master vendors - Above threshold results

--- a/features/services/supply_teachers/rm6238/jounrey/master_vendor/master_vendor_below_threshold.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/master_vendor/master_vendor_below_threshold.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - Master vendors - Below threshold
 
   Scenario: Master vendors - Below threshold results

--- a/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/effects_of_holiday.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/effects_of_holiday.feature
@@ -10,7 +10,6 @@ Feature: Supply Teachers - Temp to perm - Effects of holiday
     And I enter '25' for the 'daily fee'
     Given I enter '29/03/2021' for the 'hire' date
 
-  @pipeline
   Scenario: Adding one week of holiday has the same affect as reducing the hire date by one week
     Given I enter '07/03/2021' for the 'holiday 1 start' date
     And I enter '13/03/2021' for the 'holiday 1 end' date

--- a/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/no_notice_given/hiring_after_12_weeks.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/no_notice_given/hiring_after_12_weeks.feature
@@ -10,7 +10,6 @@ Feature: Supply Teachers - Temp to perm - No notice given - hiring after 12 week
     And I enter '25' for the 'daily fee'
     Given I enter '03/08/2021' for the 'hire' date
 
-  @pipeline
   Scenario Outline: Changing the length of the current contract does not change the result
     Given I enter '<date>' for the 'hire' date
     And I click on 'Continue'
@@ -24,7 +23,6 @@ Feature: Supply Teachers - Temp to perm - No notice given - hiring after 12 week
       | 03/09/2021  |
       | 03/10/2021  |
 
-  @pipeline
   Scenario Outline: Changing the number of days per week changes the result
     And I enter '<days_per_week>' for the 'days per week'
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/no_notice_given/hiring_before_9_weeks.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/no_notice_given/hiring_before_9_weeks.feature
@@ -10,7 +10,6 @@ Feature: Supply Teachers - Temp to perm - No notice given - hiring before 9 week
     And I enter '25' for the 'daily fee'
     Given I enter '31/05/2021' for the 'hire' date
 
-  @pipeline
   Scenario Outline: Changing the length of the current contract changes the result
     Given I enter '<date>' for the 'hire' date
     And I click on 'Continue'
@@ -40,7 +39,6 @@ Feature: Supply Teachers - Temp to perm - No notice given - hiring before 9 week
       | 4             | £440.00 |
       | 5             | £550.00 |
 
-  @pipeline
   Scenario Outline: Changing the daily fee changes the result
     And I enter '<daily_fee>' for the 'daily fee'
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/no_notice_given/hiring_between_9_and_12_weeks.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/no_notice_given/hiring_between_9_and_12_weeks.feature
@@ -10,7 +10,6 @@ Feature: Supply Teachers - Temp to perm - No notice given - hiring between 9 and
     And I enter '25' for the 'daily fee'
     Given I enter '19/06/2021' for the 'hire' date
 
-  @pipeline
   Scenario Outline: Changing the length of the current contract changes the result
     Given I enter '<date>' for the 'hire' date
     And I click on 'Continue'
@@ -40,7 +39,6 @@ Feature: Supply Teachers - Temp to perm - No notice given - hiring between 9 and
       | 4             | £160.00 | £400    |
       | 5             | £200.00 | £500    |
 
-  @pipeline
   Scenario Outline: Changing the daily fee changes the result
     And I enter '<daily_fee>' for the 'daily fee'
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/notice_given/results.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/notice_given/results.feature
@@ -11,7 +11,6 @@ Feature: Supply Teachers - Temp to perm - Notice given - hiring between 9 and 12
     And I enter '19/06/2021' for the 'hire' date
     And I enter '30/05/2021' for the 'notice' date
 
-  @pipeline
   Scenario Outline: Changing the length of the notice period changes the result
     Given I enter '<date>' for the 'notice' date
     And I click on 'Continue'

--- a/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/results.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/temp_to_perm/results.feature
@@ -9,7 +9,6 @@ Feature: Supply Teachers - Temp to perm - Results
     And I enter '5' for the 'days per week'
     And I enter '25.50' for the 'daily fee'
 
-  @pipeline
   Scenario: Hiring after 12 weeks - no notice
     Given I enter '12/12/2021' for the 'hire' date
     And I click on 'Continue'
@@ -35,7 +34,6 @@ Feature: Supply Teachers - Temp to perm - Results
       | but you’re not giving 4 working weeks’ notice, so you can be charged a fee.                         |
       | Notice period given: 3 working days between Wednesday 08 December 2021 and Sunday 12 December 2021  |
 
-  @pipeline
   Scenario: Hiring after 12 weeks - enough notice
     Given I enter '12/12/2021' for the 'hire' date
     Given I enter '11/11/2021' for the 'notice' date
@@ -55,7 +53,6 @@ Feature: Supply Teachers - Temp to perm - Results
       | Working days between contract start (Saturday 03 April 2021) and hire date (Saturday 19 June 2021): 52              |
       | Difference: 8 working days                                                                                          |
 
-  @pipeline
   Scenario: Hiring between 9 and 12 weeks - not enough notice
     Given I enter '19/06/2021' for the 'hire' date
     Given I enter '10/06/2021' for the 'notice' date
@@ -75,7 +72,6 @@ Feature: Supply Teachers - Temp to perm - Results
       | Based on the information you provided, you’re taking the worker on within the first 12 working weeks  |
       | of their contract, so you can be charged a fee even though you’ve given 4 working weeks’ notice.      |
 
-  @pipeline
   Scenario Outline: Hiring before 9 - notice period does not change result
     Given I enter '29/05/2021' for the 'hire' date
     Given I enter '<date>' for the 'notice' date

--- a/features/services/supply_teachers/rm6238/jounrey/validations/agency_results/fixed_term_validation.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/validations/agency_results/fixed_term_validation.feature
@@ -1,4 +1,4 @@
-@pipeline @javascript @geocode_liverpool
+@javascript @geocode_liverpool
 Feature: Supply Teachers - Agency results - Fixed term - Validations
 
   Background: Navigate to the Agency results page

--- a/features/services/supply_teachers/rm6238/jounrey/validations/agency_results_validations.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/validations/agency_results_validations.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - Find individual worker - Validations
 
   Background: Navigate to the Do you want an agency to supply the worker? page

--- a/features/services/supply_teachers/rm6238/jounrey/validations/fta_to_perm_validations.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/validations/fta_to_perm_validations.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - FTA to perm - Validations
 
   Background: Navigate to the FTA to perm section

--- a/features/services/supply_teachers/rm6238/jounrey/validations/journey_validations.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/validations/journey_validations.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - Jounrey validations
 
   Scenario: What is your school looking for? validations

--- a/features/services/supply_teachers/rm6238/jounrey/validations/master_vendor_validations.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/validations/master_vendor_validations.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - Master Vendor validations
 
   Scenario: Is your contract likely to be worth more than £2.5 million? validations

--- a/features/services/supply_teachers/rm6238/jounrey/validations/temp_to_perm_validations.feature
+++ b/features/services/supply_teachers/rm6238/jounrey/validations/temp_to_perm_validations.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - Temp to perm - Validations
 
   Background: Navigate to the Find out how much you’ll be charged page

--- a/features/services/supply_teachers/unrecognised_framework.feature
+++ b/features/services/supply_teachers/unrecognised_framework.feature
@@ -1,4 +1,3 @@
-@pipeline
 Feature: Supply Teachers - Start pages - With an unrecognised framework
 
   Scenario Outline: Go to unrecognised famework in the buyer section - logged in

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -37,12 +37,6 @@ unless ARGV.any? { |a| a =~ /^gems/ } # Don't load anything when running the gem
         t.profile = 'accessibility'
       end
 
-      Cucumber::Rake::Task.new({ pipeline: 'test:prepare' }, 'Run cut down suite for the pipeline') do |t|
-        t.binary = vendored_cucumber_bin
-        t.fork = true # You may get faster startup if you set this to false
-        t.profile = 'pipeline'
-      end
-
       desc 'Run all features'
       task all: %i[ok wip]
 


### PR DESCRIPTION
I’ve removed the pipeline restrictions for feature tests as I do not think such restrictions are necessary. We originally had this restriction because some of the feature tests were flakey but this is no longer the case.

When we merge a PR it will run all the tests anyway so there is no point having PRs that pass but then release that fail due to a missed change. This will make PRs a bit longer but that should be fine.