### PR TITLE
FMFR-1360 - Make sure user entered emails are downcased

### DIFF
--- a/app/services/cognito/confirm_sign_up.rb
+++ b/app/services/cognito/confirm_sign_up.rb
@@ -11,7 +11,7 @@ module Cognito
               length: { is: 6, message: :invalid_length }
 
     def initialize(email, confirmation_code)
-      @email = email
+      @email = email.try(:downcase)
       @confirmation_code = confirmation_code
       @error = nil
     end

--- a/app/services/cognito/forgot_password.rb
+++ b/app/services/cognito/forgot_password.rb
@@ -6,7 +6,7 @@ module Cognito
     validates :email, format: { with: /\A([\w+-].?)+@[a-z\d-]+(\.[a-z]+)*\.[a-z]+\z/i }
 
     def initialize(email)
-      @email = email
+      @email = email.try(:downcase)
       @error = nil
     end
 

--- a/spec/services/cognito/confirm_sign_up_spec.rb
+++ b/spec/services/cognito/confirm_sign_up_spec.rb
@@ -2,17 +2,16 @@ require 'rails_helper'
 
 RSpec.describe Cognito::ConfirmSignUp do
   let(:email) { 'user@test.com' }
-  let(:user) { create(:user, email: email, confirmed_at: nil) }
+  let!(:user) { create(:user, email: email, confirmed_at: nil) }
   let(:confirmation_code) { '123456' }
   let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
 
-  describe '#validations' do
-    let(:response) { described_class.new(user.email, confirmation_code) }
+  before { allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client) }
 
-    before do
-      allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-      allow(aws_client).to receive(:confirm_sign_up).and_return(JSON[{ user_sub: '1234'.to_json }])
-    end
+  describe '#validations' do
+    let(:response) { described_class.new(email, confirmation_code) }
+
+    before { allow(aws_client).to receive(:confirm_sign_up).and_return(JSON[{ user_sub: '1234'.to_json }]) }
 
     context 'when confirmation_code shorter than 6 characters' do
       let(:confirmation_code) { '123' }
@@ -48,11 +47,10 @@ RSpec.describe Cognito::ConfirmSignUp do
   end
 
   describe '#call' do
-    let(:response) { described_class.call(user.email, confirmation_code) }
+    let(:response) { described_class.call(email, confirmation_code) }
 
     context 'when success' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:confirm_sign_up).and_return(JSON[{ user_sub: '1234'.to_json }])
         response
       end
@@ -71,9 +69,34 @@ RSpec.describe Cognito::ConfirmSignUp do
       end
     end
 
+    context 'when success with an upercase email' do
+      let(:email) { 'User@Test.com' }
+
+      before do
+        allow(aws_client).to receive(:confirm_sign_up).and_return(JSON[{ user_sub: '1234'.to_json }])
+        response
+      end
+
+      it 'converts the email to lowercase' do
+        expect(response.email).to eq('user@test.com')
+      end
+
+      it 'returns success' do
+        expect(response.success?).to be true
+      end
+
+      it 'returns no error' do
+        expect(response.error).to be_nil
+      end
+
+      it 'confirms user' do
+        user.reload
+        expect(user.confirmed?).to be true
+      end
+    end
+
     context 'when cognito error' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:confirm_sign_up).and_raise(error.new('Some context', 'Some message'))
         response
       end

--- a/spec/services/cognito/create_user_from_cognito_spec.rb
+++ b/spec/services/cognito/create_user_from_cognito_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Cognito::CreateUserFromCognito do
-  include_context 'with cognito structs'
-
   describe '#call' do
+    include_context 'with cognito structs'
+
     let(:username) { '123456' }
     let(:email) { 'user@email.com' }
     let(:name) { 'Scooby' }
@@ -32,120 +32,103 @@ RSpec.describe Cognito::CreateUserFromCognito do
 
     let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
 
+    let(:response) { described_class.call(username) }
+
+    before { allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client) }
+
     context 'when success' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:admin_get_user).and_return(cognito_user)
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
       end
 
       it 'creates user' do
-        expect { described_class.call(username) }.to change(User, :count).by 1
+        expect { response }.to change(User, :count).by 1
       end
 
       it 'returns the newly created resource' do
-        response = described_class.call(username)
         expect(response.user).to eq User.order(created_at: :asc).last
       end
 
       it 'returns the newly created resource with the right email' do
-        response = described_class.call(username)
         expect(response.user.email).to eq email
       end
 
       it 'returns the newly created resource with the right first name' do
-        response = described_class.call(username)
         expect(response.user.first_name).to eq name
       end
 
       it 'returns the newly created resource with the right last name' do
-        response = described_class.call(username)
         expect(response.user.last_name).to eq family_name
       end
 
       it 'returns the newly created resource with the right phone number' do
-        response = described_class.call(username)
         expect(response.user.phone_number).to eq phone_number
       end
 
       it 'returns the newly created resource with the buyer and st_access role' do
-        response = described_class.call(username)
         expect(response.user.has_role?(:buyer)).to be true
         expect(response.user.has_role?(:st_access)).to be true
       end
 
       it 'returns the newly created resource with no fm_access role' do
-        response = described_class.call(username)
         expect(response.user.has_role?(:fm_access)).to be false
       end
 
       it 'returns the newly created resource with no ls_access role' do
-        response = described_class.call(username)
         expect(response.user.has_role?(:ls_access)).to be false
       end
 
       it 'returns the newly created resource with no mc_access role' do
-        response = described_class.call(username)
         expect(response.user.has_role?(:mc_access)).to be false
       end
 
       it 'returns success' do
-        response = described_class.call(username)
         expect(response.success?).to be true
       end
 
       it 'returns no error' do
-        response = described_class.call(username)
         expect(response.error).to be_nil
       end
     end
 
     context 'when user already exists' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:admin_get_user).and_return(cognito_user)
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
         create(:user, cognito_uuid: '0987', email: email, roles: %i[buyer fm_access])
       end
 
       it 'does not create a new user' do
-        expect { described_class.call(username) }.not_to change(User, :count)
+        expect { response }.not_to change(User, :count)
       end
 
       it 'updates cognito_uuid' do
-        response = described_class.call(username)
         expect(response.user.cognito_uuid).to eq username
       end
 
       it 'updates roles' do
-        response = described_class.call(username)
         expect(response.user.has_role?(:st_access)).to be true
         expect(response.user.has_role?(:buyer)).to be true
       end
     end
 
     context 'when cognito error' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:admin_get_user).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops'))
-      end
+      before { allow(aws_client).to receive(:admin_get_user).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops')) }
 
       it 'does not create user' do
-        expect { described_class.call(username) }.not_to change(User, :count)
+        expect { response }.not_to change(User, :count)
       end
 
       it 'does not return user' do
-        response = described_class.call(username)
         expect(response.user).to be_nil
       end
 
       it 'does not return success' do
-        response = described_class.call(username)
         expect(response.success?).to be false
       end
 
       it 'returns an error' do
-        response = described_class.call(username)
         expect(response.error).to eq 'Oops'
       end
     end

--- a/spec/services/cognito/forgot_password_spec.rb
+++ b/spec/services/cognito/forgot_password_spec.rb
@@ -2,19 +2,39 @@ require 'rails_helper'
 
 RSpec.describe Cognito::ForgotPassword do
   let(:email) { 'test@email.com' }
+  let(:email_upercase) { 'Test@Email.com' }
   let(:invalid_email_char) { '@!"£$£"' }
   let(:invalid_email) { 'someRandomString' }
   let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
 
   describe '#call' do
+    let(:response) { described_class.call(email) }
+
+    before { allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client) }
+
     context 'when success' do
       include_context 'with cognito structs'
 
-      let(:response) { described_class.call(email) }
+      before { allow(aws_client).to receive(:forgot_password).and_return(forgot_password_resp_struct.new('USER_ID_FOR_SRP' => email)) }
 
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:forgot_password).and_return(forgot_password_resp_struct.new('USER_ID_FOR_SRP' => email))
+      it 'returns success' do
+        expect(response.success?).to be true
+      end
+
+      it 'returns no error' do
+        expect(response.error).to be_nil
+      end
+    end
+
+    context 'when success with an upercase email' do
+      let(:email) { email_upercase }
+
+      include_context 'with cognito structs'
+
+      before { allow(aws_client).to receive(:forgot_password).and_return(forgot_password_resp_struct.new('USER_ID_FOR_SRP' => email)) }
+
+      it 'converts the email to lowercase' do
+        expect(response.email).to eq('test@email.com')
       end
 
       it 'returns success' do
@@ -27,67 +47,49 @@ RSpec.describe Cognito::ForgotPassword do
     end
 
     context 'when cognito error' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:forgot_password).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops'))
-      end
+      before { allow(aws_client).to receive(:forgot_password).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops')) }
 
       it 'does not return success' do
-        response = described_class.call(email)
         expect(response.success?).to be false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(email)
         expect(response.error).to eq 'Oops'
       end
     end
 
     context 'when cognito error is UserNotFoundException' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:forgot_password).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('oops', 'Oops'))
-      end
+      before { allow(aws_client).to receive(:forgot_password).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('oops', 'Oops')) }
 
       it 'does not return success' do
-        response = described_class.call(email)
         expect(response.success?).to be true
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(email)
         expect(response.error).to be_nil
       end
     end
 
     context 'when user enter invalid_email_char' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-      end
+      let(:email) { invalid_email_char }
 
       it 'does not return success' do
-        response = described_class.call(invalid_email_char)
         expect(response.success?).to be false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(invalid_email_char)
         expect(response.error).to eq 'Enter your email address in the correct format, like name@example.com'
       end
     end
 
     context 'when user enter invalid_email' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-      end
+      let(:email) { invalid_email }
 
       it 'does not return success' do
-        response = described_class.call(invalid_email)
         expect(response.success?).to be false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(invalid_email)
         expect(response.error).to eq 'Enter your email address in the correct format, like name@example.com'
       end
     end

--- a/spec/services/cognito/resend_confirmation_code_spec.rb
+++ b/spec/services/cognito/resend_confirmation_code_spec.rb
@@ -4,16 +4,15 @@ RSpec.describe Cognito::ResendConfirmationCode do
   let(:email) { create(:user, cognito_uuid: '12345').email }
   let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
 
+  let(:response) { described_class.call(email) }
+
+  before { allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client) }
+
   describe '#call' do
     context 'when success' do
       include_context 'with cognito structs'
 
-      let(:response) { described_class.call(email) }
-
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:resend_confirmation_code).and_return(resend_confirmation_code_resp_struct.new('USER_ID_FOR_SRP' => email))
-      end
+      before { allow(aws_client).to receive(:resend_confirmation_code).and_return(resend_confirmation_code_resp_struct.new('USER_ID_FOR_SRP' => email)) }
 
       it 'returns success' do
         expect(response.success?).to be true
@@ -25,18 +24,13 @@ RSpec.describe Cognito::ResendConfirmationCode do
     end
 
     context 'when cognito error' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:resend_confirmation_code).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops'))
-      end
+      before { allow(aws_client).to receive(:resend_confirmation_code).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops')) }
 
       it 'does not return success' do
-        response = described_class.call(email)
         expect(response.success?).to be false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(email)
         expect(response.error).to eq 'Oops'
       end
     end


### PR DESCRIPTION
Ticket: [FMFR-1360](https://crowncommercialservice.atlassian.net/browse/FMFR-1360)

I have made sure that the email is lowercased for the forgot password and confirm sign up routes (where the user has to enter an email).
In addition, I have refactored all of the cognito service unit tests.