### PR TITLE
Remove turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,6 @@ gem 'sass-rails', '~> 5.1', '>= 5.1.0'
 
 gem 'shakapacker', '~> 6.5.6'
 
-gem 'turbolinks', '~> 5'
-
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.11', '>= 2.11.5'
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -594,9 +594,6 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.11)
     timeout (0.3.1)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2021.1)
@@ -710,7 +707,6 @@ DEPENDENCIES
   site_prism (>= 3.7.3)
   slim (~> 5.0.0)
   sprockets (>= 3.7.2)
-  turbolinks (~> 5)
   tzinfo-data
   uk_postcode
   virtus

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -16,11 +16,9 @@
 
 import jQuery from 'jquery'
 import Rails from '@rails/ujs'
-import Turbolinks from 'turbolinks'
 
 // Initiate @rails/ujs
 Rails.start()
-Turbolinks.start()
 
 // Initiate jQuery
 // eslint-disable-next-line no-undef

--- a/app/javascript/packs/ccs.ts
+++ b/app/javascript/packs/ccs.ts
@@ -6,7 +6,7 @@ import initPasswordStrength from '../src/shared/passwordStrength'
 import initSupplyTeachersAdminUpload from '../src/supplyTeachers/adminUpload'
 import initSupplyTeachersSupplierMarkupCalculator from '../src/supplyTeachers/supplierMarkupCalculator'
 
-$(document).on('turbolinks:load', () => {
+$(() => {
   initAdminUpload()
   initBasket()
   initCookieBanner()

--- a/app/javascript/packs/govuk.js
+++ b/app/javascript/packs/govuk.js
@@ -1,6 +1,4 @@
 // Initiate GOV.UK Frontend
 import { initAll } from 'govuk-frontend'
 
-$(document).on('turbolinks:load', () => {
-  initAll()
-})
+$(() => initAll())

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "js-cookie": "^3.0.1",
     "shakapacker": "6.5.6",
     "terser-webpack-plugin": "^5.3.7",
-    "turbolinks": "^5.2.0",
     "typescript": "^4.9.5",
     "webpack": "^5.76.0",
     "webpack-assets-manifest": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4659,11 +4659,6 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
-turbolinks@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
-
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"


### PR DESCRIPTION
I had not properly considered the effect of using turbolinks within the application. On the surface it seemed to be fine but there were some issues with caching and the back/forward buttons that I had not considered.

I may investigate using turbolinks (or perhaps something similar) in a future update (see: [FMFR-1326](https://crowncommercialservice.atlassian.net/browse/FMFR-1362)).

[FMFR-1326]: https://crowncommercialservice.atlassian.net/browse/FMFR-1326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ