### PR TITLE
FMFR-1364 - Add auto session timeout for legacy services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,10 @@ gem 'json-jwt', '>= 1.11.0'
 
 # for authentication
 gem 'devise', '~> 4.9.2'
+
+# for timing out when session expires
+gem 'auto-session-timeout', '~> 1.0'
+
 # for cognito
 gem 'aws-sdk-cognitoidentityprovider', '~> 1.73.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
       unf
     ast (2.4.2)
     attr_required (1.0.1)
+    auto-session-timeout (1.0)
+      actionpack (>= 3.2, < 7.1)
     aws-eventstream (1.2.0)
     aws-partitions (1.739.0)
     aws-sdk-cognitoidentityprovider (1.73.0)
@@ -648,6 +650,7 @@ DEPENDENCIES
   active_storage_validations (>= 1.0.3)
   activerecord-postgis-adapter (>= 6.0.3)
   asset_sync
+  auto-session-timeout (~> 1.0)
   aws-sdk-cognitoidentityprovider (~> 1.73.0)
   aws-sdk-s3 (~> 1)
   axe-core-capybara (>= 4.2.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   class UnrecognisedFrameworkError < StandardError; end
   class UnrecognisedLiveFrameworkError < StandardError; end
+  auto_session_timeout Devise.timeout_in
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery with: :exception

--- a/app/controllers/base/sessions_controller.rb
+++ b/app/controllers/base/sessions_controller.rb
@@ -3,9 +3,9 @@ module Base
     include Base::AuthenticationPathsConcern
 
     skip_forgery_protection
-    before_action :authenticate_user!, except: %i[new create destroy]
-    before_action :authorize_user, except: %i[new create destroy]
-    before_action :validate_service, except: :destroy
+    before_action :authenticate_user!, except: %i[new create destroy active timeout]
+    before_action :authorize_user, except: %i[new create destroy active timeout]
+    before_action :validate_service, except: %i[destroy active timeout]
 
     helper_method :new_user_session_path, :new_user_password_path, :sign_up_path
 
@@ -31,6 +31,20 @@ module Base
       current_user.invalidate_session!
       current_user.save!
       super
+    end
+
+    def active
+      render_session_status
+    end
+
+    def timeout
+      session[:return_to] = params[:url]
+
+      begin
+        redirect_to "#{params[:service_path_base]}/sign-in?expired=true"
+      rescue ActionController::RoutingError
+        redirect_to "#{service_path_base}/sign-in?expired=true"
+      end
     end
 
     protected

--- a/app/views/base/sessions/new.html.erb
+++ b/app/views/base/sessions/new.html.erb
@@ -1,13 +1,17 @@
 <%= content_for :page_title, local_header_text %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= warning_text(t('.session_expired')) if params[:expired] == 'true' %>
+
+    <%= render partial: 'shared/error_summary', locals: { errors: @result.errors } %>
+
     <h1 class="govuk-heading-xl">
       <%= local_header_text %>
     </h1>
 
-    <%= render partial: 'shared/error_summary', locals: { errors: @result.errors } %>
-
     <%= form_for resource, as: resource_name, url: new_user_session_path, method: :post, html: { specialvalidation: true, novalidate: true, class: 'ccs-form', id: 'cop_sign_in_form'} do |f| %>
+      <input type="hidden" name="expired" value="<%= params[:expired]%>"/>
       <div class="govuk-form-group govuk-!-margin-bottom-4 <%= 'govuk-form-group--error' if @result.errors[:email].any? %>">
         <label class="govuk-label govuk-label--m govuk-!-margin-bottom-0" for="email">
           <%=  t('.email_address')%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,9 @@
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
+    <% if Rails.env.production? && user_signed_in? %>
+      <%= auto_session_timeout_js %>
+    <% end %>
 
     <div id="wrapper">
       <%= link_to t('.skip'), '#main-content', class: 'govuk-skip-link', data: { module: 'govuk-skip-link', turbolinks: false } %>

--- a/config/initializers/ext.rb
+++ b/config/initializers/ext.rb
@@ -1,1 +1,2 @@
 require(Rails.root.join('lib', 'ext', 'ruby', 'gov_uk_date_fields', 'form_fields', 'generate_input_fields.rb'))
+require(Rails.root.join('lib', 'ext', 'ruby', 'auto_session_timeout_helper.rb'))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,7 @@ en:
         password: Password
         please_enter_a_valid_email_address: You must provide your email address in the correct format, like name@example.com
         problems_signing_in: Problems signing in
+        session_expired: Sorry, your session has timed out due to 30 minutes of inactivity. To continue using this service, you need to sign in again.
     users:
       confirm_new:
         confirmation_code: Confirmation code

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,9 @@ Rails.application.routes.draw do
         end
       end
     end
+
+    get '/legacy-session/active'  => 'base/sessions#active', as: :active
+    get '/legacy-session/timeout' => 'base/sessions#timeout', as: :timeout
   end
 
   concern :buyer_shared_pages do

--- a/lib/ext/ruby/auto_session_timeout_helper.rb
+++ b/lib/ext/ruby/auto_session_timeout_helper.rb
@@ -1,0 +1,32 @@
+module AutoSessionTimeoutHelper
+  def auto_session_timeout_js(options = {})
+    frequency = options[:frequency] || 60
+    attributes = options[:attributes] || {}
+    code = <<~JS
+      function PeriodicalQuery() {
+        var request = new XMLHttpRequest();
+        request.onload = function (event) {
+          var status = event.target.status;
+          var response = event.target.response;
+          if (status === 200 && (response === false || response === 'false' || response === null)) {
+            window.location.href = timout_url;
+          }
+          };
+          request.open('GET', '#{active_path}', true);
+          request.responseType = 'json';
+          request.send();
+          setTimeout(PeriodicalQuery, (#{frequency} * 1000));
+        }
+
+      var current_url = encodeURIComponent(window.location.pathname +  window.location.search);
+      var service_path_base = encodeURIComponent('#{service_path_base}');
+
+      var timout_url = `#{timeout_path}?url=${current_url}&service_path_base=${service_path_base}`;
+
+      setTimeout(PeriodicalQuery, (#{frequency} * 1000));
+    JS
+    javascript_tag(code, attributes)
+  end
+end
+
+ActiveSupport.on_load(:action_view) { include AutoSessionTimeoutHelper }

--- a/spec/controllers/base/sessions_controller_spec.rb
+++ b/spec/controllers/base/sessions_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Base::SessionsController do
+  before { request.env['devise.mapping'] = Devise.mappings[:user] }
+
+  describe 'GET active' do
+    context 'when the user is signed in' do
+      login_ls_buyer
+
+      before { get :active }
+
+      it 'returns the 200 status and a body of true' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq('true')
+      end
+    end
+
+    context 'when the user is signed out' do
+      before { get :active }
+
+      it 'returns the 200 status and a body of false' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq('false')
+      end
+    end
+  end
+
+  describe 'GET timeout' do
+    context 'when there is no error' do
+      before { get :timeout, params: { url: '/management-consultancy/RM6187', service_path_base: service_path_base } }
+
+      context 'and service_path_base is provided' do
+        let(:service_path_base) { '/management-consultancy/RM6187' }
+
+        it 'redirects to the service base path param sign in path' do
+          expect(response).to redirect_to('/management-consultancy/RM6187/sign-in?expired=true')
+        end
+      end
+
+      context 'and service_path_base is not provided' do
+        let(:service_path_base) { nil }
+
+        it 'redirects to just the sign in path' do
+          expect(response).to redirect_to('/sign-in?expired=true')
+        end
+      end
+    end
+
+    context 'when the service_path_base would raise to a routing error' do
+      before do
+        allow(controller).to receive(:redirect_to).with('/legal-services/RM7007/admin/sign-in?expired=true').and_raise(ActionController::RoutingError.new('Some error', 'Some Message'))
+        allow(controller).to receive(:redirect_to).with('/supply-teachers/RM6238/sign-in?expired=true').and_call_original
+
+        get :timeout, params: { url: '/legal-services/RM7007/admin', service_path_base: '/legal-services/RM7007/admin' }
+      end
+
+      it 'redirects to the default sign in path' do
+        expect(controller).to have_received(:redirect_to).with('/legal-services/RM7007/admin/sign-in?expired=true')
+        expect(controller).to have_received(:redirect_to).with('/supply-teachers/RM6238/sign-in?expired=true')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [FMFR-1364](https://crowncommercialservice.atlassian.net/browse/FMFR-1364)

Add auto session timeout for legacy services

We need to also update load balancer to change the rule that says  `/legacy-storage*` to `/legacy*` as we need the auto timeout to hit the right server when it is making the calls.