### PR TITLE
Rename `cookie_preferences` cookie to `cookie_preferences_cmp` so that it does not conflict with corporate website

### DIFF
--- a/app/javascript/src/shared/cookieBanner.ts
+++ b/app/javascript/src/shared/cookieBanner.ts
@@ -27,7 +27,7 @@ const cookieUpdateOptions: CookieUpdateOption[] = [
 const getCookiePreferences = (): CookiePreferences => {
   const defaultCookieSettings = '{"usage":true,"glassbox":false}'
 
-  return JSON.parse(Cookies.get('cookie_preferences') ?? defaultCookieSettings)
+  return JSON.parse(Cookies.get('cookie_preferences_cmp') ?? defaultCookieSettings)
 }
 
 const removeUnwantedCookies = (): void => {

--- a/app/javascript/src/shared/googleAnalyticsDataLayer.ts
+++ b/app/javascript/src/shared/googleAnalyticsDataLayer.ts
@@ -20,12 +20,12 @@ declare global {
 }
 
 
-const getCookiePreferences = (): string => Cookies.get('cookie_preferences') ?? '{}'
+const getCookiePreferences = (): string => Cookies.get('cookie_preferences_cmp') ?? '{}'
 
-const getCookiePreferencesSaved = (): string => Cookies.get('cookie_preferences_saved') ?? '{}'
+const getCookiePreferencesSaved = (): string => Cookies.get('cookie_preferences_cmp_saved') ?? '{}'
 
 const setCookiePreferencesSaved = (cookiePreferences: CookiePreferences) => {
-  Cookies.set('cookie_preferences_saved', JSON.stringify(cookiePreferences), { expires: 365 })
+  Cookies.set('cookie_preferences_cmp_saved', JSON.stringify(cookiePreferences), { expires: 365 })
 }
 
 const getGrantedText = (state: boolean) => state ? GrantType.GRANTED : GrantType.NOT_GRANTED

--- a/config/application.rb
+++ b/config/application.rb
@@ -168,7 +168,7 @@ module Marketplace
   end
 
   def self.cookie_settings_name
-    :cookie_preferences
+    :cookie_preferences_cmp
   end
 
   def self.default_cookie_options

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,7 +330,7 @@ en:
           purpose: Saves your cookie consent preferences
         row_2:
           expires: 1 year
-          name: cookie_preferences_saved
+          name: cookie_preferences_cmp_saved
           purpose: Allows us to check when your cookie settings have changed
       cookies_banner: Cookies banner
       ga_cookies:

--- a/features/helpers/cookies_helper.rb
+++ b/features/helpers/cookies_helper.rb
@@ -1,5 +1,5 @@
 def update_banner_cookie(status)
-  page.driver.browser.manage.add_cookie(name: 'cookie_preferences', value: {
+  page.driver.browser.manage.add_cookie(name: 'cookie_preferences_cmp', value: {
     settings_viewed: status,
     usage: false,
     glassbox: false

--- a/features/step_definitions/home_steps.rb
+++ b/features/step_definitions/home_steps.rb
@@ -91,5 +91,5 @@ COOKIE_TO_OPTION = {
 }.freeze
 
 def cookie_settings
-  JSON.parse(CGI.unescape(page.driver.browser.manage.cookie_named('cookie_preferences')[:value]))
+  JSON.parse(CGI.unescape(page.driver.browser.manage.cookie_named('cookie_preferences_cmp')[:value]))
 end

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -20,7 +20,7 @@ After('@allow_list') do
 end
 
 Before('not @javascript') do
-  page.driver.browser.set_cookie('cookie_preferences=%7B%22settings_viewed%22%3Atrue%2C%22usage%22%3Afalse%2C%22glassbox%22%3Afalse%7D')
+  page.driver.browser.set_cookie('cookie_preferences_cmp=%7B%22settings_viewed%22%3Atrue%2C%22usage%22%3Afalse%2C%22glassbox%22%3Afalse%7D')
 end
 
 Before('@geocode_london') do

--- a/spec/controllers/legal_services/rm6240/admin/uploads_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/admin/uploads_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe LegalServices::RM6240::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -114,7 +114,7 @@ RSpec.describe LegalServices::RM6240::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -150,7 +150,7 @@ RSpec.describe LegalServices::RM6240::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -178,7 +178,7 @@ RSpec.describe LegalServices::RM6240::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/controllers/legal_services/rm6240/home_controller_spec.rb
+++ b/spec/controllers/legal_services/rm6240/home_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe LegalServices::RM6240::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -88,7 +88,7 @@ RSpec.describe LegalServices::RM6240::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -124,7 +124,7 @@ RSpec.describe LegalServices::RM6240::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -152,7 +152,7 @@ RSpec.describe LegalServices::RM6240::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/controllers/management_consultancy/rm6187/admin/uploads_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/admin/uploads_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -115,7 +115,7 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -151,7 +151,7 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -179,7 +179,7 @@ RSpec.describe ManagementConsultancy::RM6187::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/controllers/management_consultancy/rm6187/home_controller_spec.rb
+++ b/spec/controllers/management_consultancy/rm6187/home_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ManagementConsultancy::RM6187::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -85,7 +85,7 @@ RSpec.describe ManagementConsultancy::RM6187::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -121,7 +121,7 @@ RSpec.describe ManagementConsultancy::RM6187::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -149,7 +149,7 @@ RSpec.describe ManagementConsultancy::RM6187::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/controllers/supply_teachers/rm6238/admin/uploads_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/admin/uploads_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe SupplyTeachers::RM6238::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -116,7 +116,7 @@ RSpec.describe SupplyTeachers::RM6238::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -152,7 +152,7 @@ RSpec.describe SupplyTeachers::RM6238::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -180,7 +180,7 @@ RSpec.describe SupplyTeachers::RM6238::Admin::UploadsController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/controllers/supply_teachers/rm6238/home_controller_spec.rb
+++ b/spec/controllers/supply_teachers/rm6238/home_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe SupplyTeachers::RM6238::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -88,7 +88,7 @@ RSpec.describe SupplyTeachers::RM6238::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -124,7 +124,7 @@ RSpec.describe SupplyTeachers::RM6238::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -152,7 +152,7 @@ RSpec.describe SupplyTeachers::RM6238::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe ApplicationHelper do
     end
 
     context 'when the cookie has been set' do
-      before { helper.request.cookies['cookie_preferences'] = cookie_settings }
+      before { helper.request.cookies['cookie_preferences_cmp'] = cookie_settings }
 
       context 'and it is a hash' do
         let(:expected_cookie_settings) do

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'layouts/application.html.erb' do
   before do
     allow(view).to receive_messages(user_signed_in?: false, ccs_homepage_url: 'https://CCSHOMEPAGE', service_path_base: '/supply-teachers')
 
-    cookies[:cookie_preferences] = {
+    cookies[:cookie_preferences_cmp] = {
       value: {
         'settings_viewed' => true,
         'usage' => true,


### PR DESCRIPTION
Because the cookie_preferences is set by the corporate website which has the .crowncommercial.gov.uk, it will supersede any cookie we set as Crown Marketplace is hosted on a subdomain. Therefore, I have renamed the cookie to remove this conflict.