### PR TITLE
removing underline for prospectus link

### DIFF
--- a/app/views/legal_services/suppliers/_supplier_framework.html.erb
+++ b/app/views/legal_services/suppliers/_supplier_framework.html.erb
@@ -16,7 +16,7 @@
       
       <% if link_url.present? %>
         <div class="ccs-results-list__prospectus">
-          <%= link_to link_url, url_formatter(link_url), class: 'govuk-link', target: '_blank', rel: 'noopener' %>
+          <%= link_to link_url, url_formatter(link_url), class: 'govuk-link ccs-no-underline' %>
         </div>
       <% end %>
     <% end %>


### PR DESCRIPTION
<img width="862" height="542" alt="Screenshot 2026-08-06 at 11 28 58 am" src="https://github.com/user-attachments/assets/ad10899e-dc5f-4f28-a7d1-7a6d7bb23fa9" />
